### PR TITLE
add revert handling

### DIFF
--- a/packages/localnet/src/index.ts
+++ b/packages/localnet/src/index.ts
@@ -233,25 +233,7 @@ export const initLocalnet = async (port: number) => {
       await executeTx.wait();
     } catch (e) {
       const revertOptions = args[5];
-      const callOnRevert = revertOptions[1];
-      const revertAddress = revertOptions[0];
-      const revertMessage = revertOptions[3];
-      const revertContext = {
-        asset: ethers.ZeroAddress,
-        amount: 0,
-        revertMessage,
-      };
-      if (callOnRevert) {
-        console.log("Tx reverted, calling executeRevert on GatewayZEVM...");
-        try {
-          await protocolContracts.gatewayZEVM.connect(deployer).executeRevert(revertAddress, revertContext, deployOpts);
-          console.log("Call onRevert success");
-        } catch (e) {
-          console.log("Call onRevert failed:", e);
-        }
-      } else {
-        console.log("Tx reverted without callOnRevert: ", e)
-      }
+      await handleOnRevertZEVM(revertOptions, e);
     }
   });
 
@@ -272,25 +254,7 @@ export const initLocalnet = async (port: number) => {
       }
     } catch (e) {
       const revertOptions = args[9];
-      const callOnRevert = revertOptions[1];
-      const revertAddress = revertOptions[0];
-      const revertMessage = revertOptions[3];
-      const revertContext = {
-        asset: ethers.ZeroAddress,
-        amount: 0,
-        revertMessage,
-      };
-      if (callOnRevert) {
-        console.log("Tx reverted, calling executeRevert on GatewayZEVM...");
-        try {
-          await protocolContracts.gatewayZEVM.connect(deployer).executeRevert(revertAddress, revertContext, deployOpts);
-          console.log("Call onRevert success");
-        } catch (e) {
-          console.log("Call onRevert failed:", e);
-        }
-      } else {
-        console.log("Tx reverted without callOnRevert: ", e)
-      }
+      await handleOnRevertZEVM(revertOptions, e);
     }
   });
 
@@ -330,25 +294,7 @@ export const initLocalnet = async (port: number) => {
       await executeTx.wait();
     } catch (e) {
       const revertOptions = args[3];
-      const callOnRevert = revertOptions[1];
-      const revertAddress = revertOptions[0];
-      const revertMessage = revertOptions[3];
-      const revertContext = {
-        asset: ethers.ZeroAddress,
-        amount: 0,
-        revertMessage,
-      };
-      if (callOnRevert) {
-        console.log("Tx reverted, calling executeRevert on GatewayEVM...");
-        try {
-          await protocolContracts.gatewayEVM.connect(deployer).executeRevert(revertAddress, "0x", revertContext, deployOpts);
-          console.log("Call onRevert success");
-        } catch (e) {
-          console.log("Call onRevert failed:", e);
-        }
-      } else {
-        console.log("Tx reverted without callOnRevert: ", e)
-      }
+      await handleOnRevertEVM(revertOptions, e);
     }
   });
 
@@ -379,27 +325,53 @@ export const initLocalnet = async (port: number) => {
       }
     } catch (e) {
       const revertOptions = args[5];
-      const callOnRevert = revertOptions[1];
-      const revertAddress = revertOptions[0];
-      const revertMessage = revertOptions[3];
-      const revertContext = {
-        asset: ethers.ZeroAddress,
-        amount: 0,
-        revertMessage,
-      };
-      if (callOnRevert) {
-        console.log("Tx reverted, calling executeRevert on GatewayEVM...");
-        try {
-          await protocolContracts.gatewayEVM.connect(deployer).executeRevert(revertAddress, "0x", revertContext, deployOpts);
-          console.log("Call onRevert success");
-        } catch (e) {
-          console.log("Call onRevert failed:", e);
-        }
-      } else {
-        console.log("Tx reverted without callOnRevert: ", e)
-      }
+      await handleOnRevertEVM(revertOptions, e);
     }
   });
+
+  const handleOnRevertEVM = async (revertOptions: any, err: any) => {
+    const callOnRevert = revertOptions[1];
+    const revertAddress = revertOptions[0];
+    const revertMessage = revertOptions[3];
+    const revertContext = {
+      asset: ethers.ZeroAddress,
+      amount: 0,
+      revertMessage,
+    };
+    if (callOnRevert) {
+      console.log("Tx reverted, calling executeRevert on GatewayEVM...");
+      try {
+        await protocolContracts.gatewayEVM.connect(deployer).executeRevert(revertAddress, "0x", revertContext, deployOpts);
+        console.log("Call onRevert success");
+      } catch (e) {
+        console.log("Call onRevert failed:", e);
+      }
+    } else {
+      console.log("Tx reverted without callOnRevert: ", err)
+    }
+  }
+
+  const handleOnRevertZEVM = async (revertOptions: any, err: any) => {
+    const callOnRevert = revertOptions[1];
+    const revertAddress = revertOptions[0];
+    const revertMessage = revertOptions[3];
+    const revertContext = {
+      asset: ethers.ZeroAddress,
+      amount: 0,
+      revertMessage,
+    };
+    if (callOnRevert) {
+      console.log("Tx reverted, calling executeRevert on GatewayZEVM...");
+      try {
+        await protocolContracts.gatewayZEVM.connect(deployer).executeRevert(revertAddress, revertContext, deployOpts);
+        console.log("Call onRevert success");
+      } catch (e) {
+        console.log("Call onRevert failed:", e);
+      }
+    } else {
+      console.log("Tx reverted without callOnRevert: ", err)
+    }
+  }
 
   process.stdin.resume();
 

--- a/packages/localnet/src/index.ts
+++ b/packages/localnet/src/index.ts
@@ -152,11 +152,11 @@ const deployProtocolContracts = async (
   );
 
   const zrc20Factory = new ethers.ContractFactory(ZRC20.abi, ZRC20.bytecode, deployer);
-  const testZRC20 = await zrc20Factory
+  const zrc20Eth = await zrc20Factory
     .connect(fungibleModuleSigner)
     .deploy(
-      "TOKEN",
-      "TKN",
+      "ZRC-20 ETH",
+      "ZRC20ETH",
       18,
       1,
       1,
@@ -187,7 +187,7 @@ const deployProtocolContracts = async (
     systemContract,
     testEVMZeta,
     wzeta,
-    testZRC20,
+    zrc20Eth,
   };
 };
 
@@ -285,7 +285,7 @@ export const initLocalnet = async (port: number) => {
             sender,
             chainID,
           },
-          protocolContracts.testZRC20.target,
+          protocolContracts.zrc20Eth.target,
           1,
           universalContract,
           payload,


### PR DESCRIPTION
covering flow:

- GatewayEVM.execute called with address of Hello contract from example-contracts
- worker picks up Called event and forwards call to Hello contract's onCrossChainCall
- onCrossChainCall reverts
- worker calls GatewayEVM.executeRevert using RevertOptions from Called event

is this useful? also it seems localnet in general needs some modifications, for example currently it was broken because zrc20 contract was missing - in this case, onCrossChainCall expects zrc20 to be passed as arg, which zrc20 we would send if localnet doesn't deploy some?