### PR TITLE
feat: improve logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@zetachain/protocol-contracts": "10.0.0-rc8",
+    "ansis": "^3.3.2",
     "concurrently": "^8.2.2",
     "ethers": "^6.13.2",
     "hardhat": "^2.22.8",

--- a/packages/localnet/src/index.ts
+++ b/packages/localnet/src/index.ts
@@ -12,7 +12,7 @@ import ansis from "ansis";
 
 const FUNGIBLE_MODULE_ADDRESS = "0x735b14BB79463307AAcBED86DAf3322B1e6226aB";
 
-const log = (chain: "EVM" | "ZetaChain", ...messages: any[]) => {
+const log = (chain: "EVM" | "ZetaChain", ...messages: string[]) => {
   const color = chain === "ZetaChain" ? ansis.green : ansis.cyan;
   const combinedMessage = messages.join(" ");
   console.log(color(`[${ansis.bold(chain)}]: ${combinedMessage}`));
@@ -435,7 +435,7 @@ export const initLocalnet = async (port: number) => {
           .executeRevert(revertAddress, revertContext, deployOpts);
         log("ZetaChain", "Gateway: Call onRevert success");
       } catch (e) {
-        log("ZetaChain", "Gateway: Call onRevert failed", e);
+        log("ZetaChain", `Gateway: Call onRevert failed: ${e}`);
       }
     } else {
       log("ZetaChain", "Tx reverted without callOnRevert: ", err);

--- a/packages/localnet/src/index.ts
+++ b/packages/localnet/src/index.ts
@@ -250,11 +250,19 @@ export const initLocalnet = async (port: number) => {
 
       const receiver = args[2];
       const message = args[3];
-
-      log("EVM", "Gateway: 'gatewayEVM.execute' method is called");
+      log("EVM", `Calling ${receiver} with message ${message}`);
       const executeTx = await protocolContracts.gatewayEVM
         .connect(tss)
         .execute(receiver, message, deployOpts);
+
+      const logs = await provider.getLogs({
+        address: receiver,
+        fromBlock: "latest",
+      });
+
+      logs.forEach((data) => {
+        log("EVM", `Event from contract: ${JSON.stringify(data)}`);
+      });
       await executeTx.wait();
     } catch (e) {
       const revertOptions = args[5];

--- a/packages/localnet/src/index.ts
+++ b/packages/localnet/src/index.ts
@@ -18,6 +18,11 @@ const log = (chain: "EVM" | "ZetaChain", ...messages: string[]) => {
   console.log(color(`[${ansis.bold(chain)}]: ${combinedMessage}`));
 };
 
+const logErr = (chain: "EVM" | "ZetaChain", ...messages: string[]) => {
+  const combinedMessage = messages.join(" ");
+  log(chain, ansis.red(combinedMessage));
+};
+
 let protocolContracts: any;
 let deployer: Signer;
 let tss: Signer;
@@ -327,7 +332,7 @@ export const initLocalnet = async (port: number) => {
         );
       });
     } catch (e: any) {
-      log("ZetaChain", ansis.red`Error executing onCrossChainCall: ${e}`);
+      logErr("ZetaChain", `Error executing onCrossChainCall: ${e}`);
       const revertOptions = args[3];
       await handleOnRevertEVM(revertOptions, e);
     }
@@ -372,7 +377,7 @@ export const initLocalnet = async (port: number) => {
         await executeTx.wait();
       }
     } catch (e: any) {
-      log("ZetaChain", ansis.red`Error executing onCrossChainCall: ${e}`);
+      logErr("ZetaChain", `Error executing onCrossChainCall: ${e}`);
       const revertOptions = args[5];
       await handleOnRevertEVM(revertOptions, e);
     }
@@ -410,10 +415,10 @@ export const initLocalnet = async (port: number) => {
           log("EVM", `Event from onRevert: ${JSON.stringify(data)}`);
         });
       } catch (e: any) {
-        log("EVM", ansis.red`Gateway: Call onRevert failed: ${e}`);
+        logErr("EVM", `Gateway: Call onRevert failed: ${e}`);
       }
     } else {
-      log("EVM", ansis.red`Tx reverted without callOnRevert: ${err}`);
+      logErr("EVM", `Tx reverted without callOnRevert: ${err}`);
     }
   };
 

--- a/packages/localnet/src/index.ts
+++ b/packages/localnet/src/index.ts
@@ -120,7 +120,7 @@ const deployProtocolContracts = async (
     SystemContract.bytecode,
     deployer
   );
-  const systemContract = await systemContractFactory.deploy(
+  const systemContract: any = await systemContractFactory.deploy(
     ethers.ZeroAddress,
     ethers.ZeroAddress,
     ethers.ZeroAddress,
@@ -177,6 +177,9 @@ const deployProtocolContracts = async (
       gatewayZEVM.target,
       deployOpts
     );
+
+  systemContract.setGasCoinZRC20(1, zrc20Eth.target);
+  systemContract.setGasPrice(1, 1);
 
   await (wzeta as any)
     .connect(fungibleModuleSigner)

--- a/packages/tasks/src/localnet.ts
+++ b/packages/tasks/src/localnet.ts
@@ -2,6 +2,7 @@ import { task, types } from "hardhat/config";
 import { initLocalnet } from "../../localnet/src";
 import { exec } from "child_process";
 import waitOn from "wait-on";
+import ansis from "ansis";
 
 const main = async (args: any) => {
   const port = args.port || 8545;
@@ -20,10 +21,30 @@ const main = async (args: any) => {
 
   await waitOn({ resources: [`tcp:127.0.0.1:${port}`] });
 
-  const { gatewayEVM, gatewayZetaChain } = await initLocalnet(port);
+  const {
+    gatewayEVM,
+    gatewayZetaChain,
+    zetaEVM,
+    zetaZetaChain,
+    zrc20ETHZetaChain,
+  } = await initLocalnet(port);
 
-  console.log("Gateway EVM:", gatewayEVM);
-  console.log("Gateway ZetaChain:", gatewayZetaChain);
+  console.log(ansis.cyan`
+EVM Contract Addresses
+======================
+
+Gateway EVM: ${gatewayEVM}
+ZETA:        ${zetaEVM}
+`);
+
+  console.log(ansis.green`
+ZetaChain Contract Addresses
+============================
+
+Gateway ZetaChain: ${gatewayZetaChain}
+ZETA:              ${zetaZetaChain}
+ZRC-20 ETH:        ${zrc20ETHZetaChain} 
+`);
 
   process.on("SIGINT", () => {
     console.log("\nReceived Ctrl-C, shutting down anvil...");

--- a/yarn.lock
+++ b/yarn.lock
@@ -879,6 +879,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+ansis@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/ansis/-/ansis-3.3.2.tgz#15adc36fea112da95c74d309706e593618accac3"
+  integrity sha512-cFthbBlt+Oi0i9Pv/j6YdVWJh54CtjGACaMPCIrEV4Ha7HWsIjXDwseYV79TIL0B4+KfSwD5S70PeQDkPUd1rA==
+
 anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"


### PR DESCRIPTION
Nicer output to make it easier for developer to distinguish actions happening on EVM vs ZetaChain.

* Protocol contracts addresses output during initialization

<img width="1033" alt="Screenshot 2024-08-20 at 11 16 07" src="https://github.com/user-attachments/assets/9c540d02-6cbf-482e-b90e-a73bc55a14ab">

* onCrossChainCall with params
* Printing events. Events are not decoded for now (we need ABI for this), but it's better than nothing. We can also modify the interact task to watch for events after broadcasting a tx and decoding them.

<img width="1033" alt="Screenshot 2024-08-20 at 11 14 00" src="https://github.com/user-attachments/assets/73c7bb69-1999-429c-9b67-7b0f445b592d">

* set ZRC-20 withdraw fee using the system contract

Using Ansis not Chalk for colors, because Chalk doesn't support TS.