### PR TITLE
Add Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" 
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "dependabot: " 
+    labels:
+      - "dependencies" 
+    allow:
+      - dependency-name: "@zetachain/toolkit"
+      - dependency-name: "@zetachain/networks"
+      - dependency-name: "@zetachain/protocol-contracts"
+      - dependency-name: "@zetachain/universalkit"
+      - dependency-name: "@zetachain/localnet"
+


### PR DESCRIPTION
This configuration will enable Dependabot to create automatic PR's for defined `zetachain` related dependencies