### PR TITLE
fix: set correct ZRC-20 coin type

### DIFF
--- a/packages/localnet/src/createToken.ts
+++ b/packages/localnet/src/createToken.ts
@@ -44,7 +44,7 @@ export const createToken = async ({
       `ZRC20${symbol}`,
       18,
       1,
-      1,
+      isGasToken ? 1 : 2,
       1,
       systemContract.target,
       gatewayZEVM.target,


### PR DESCRIPTION
Set the correct coin type based on whether a token is gas or ERC-20.