### PR TITLE
feat: allow user to kill all processes on a given port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ tsconfig.tsbuildinfo
 .DS_Store
 .secrets
 .wallet.json
+
+localnet.pid

--- a/packages/tasks/src/localnet.ts
+++ b/packages/tasks/src/localnet.ts
@@ -12,30 +12,35 @@ const killProcessOnPort = async (port: number, forceKill: boolean) => {
   try {
     const output = execSync(`lsof -ti tcp:${port}`).toString().trim();
     if (output) {
+      const pids = output.split("\n");
       console.log(
-        ansis.yellow(`Port ${port} is already in use by process ${output}.`)
+        ansis.yellow(
+          `Port ${port} is already in use by process(es): ${pids.join(", ")}.`
+        )
       );
 
       if (forceKill) {
-        execSync(`kill -9 ${output}`);
-        console.log(
-          ansis.green(`Successfully killed process ${output} on port ${port}.`)
-        );
+        for (const pid of pids) {
+          execSync(`kill -9 ${pid}`);
+          console.log(
+            ansis.green(`Successfully killed process ${pid} on port ${port}.`)
+          );
+        }
       } else {
         const answer = await confirm({
-          message: `Do you want to kill the process running on port ${port}?`,
+          message: `Do you want to kill all processes running on port ${port}?`,
           default: true,
         });
 
         if (answer) {
-          execSync(`kill -9 ${output}`);
-          console.log(
-            ansis.green(
-              `Successfully killed process ${output} on port ${port}.`
-            )
-          );
+          for (const pid of pids) {
+            execSync(`kill -9 ${pid}`);
+            console.log(
+              ansis.green(`Successfully killed process ${pid} on port ${port}.`)
+            );
+          }
         } else {
-          console.log(ansis.red("Process not killed. Exiting..."));
+          console.log(ansis.red("Processes not killed. Exiting..."));
           process.exit(1);
         }
       }


### PR DESCRIPTION
Apparently, multiple processes can use the same port (based on the output of `lsof -ti tcp:${port}`). This PR allows the user to kill all processes in one go.

Also, added `lolcanet.pid` to gitignore.