### PR TITLE
Small fix to handle withdraw

### DIFF
--- a/packages/localnet/src/handleOnZEVMWithdrawn.ts
+++ b/packages/localnet/src/handleOnZEVMWithdrawn.ts
@@ -23,13 +23,9 @@ export const handleOnZEVMWithdrawn = async ({
   log("ZetaChain", "Gateway: 'Withdrawn' event emitted");
   try {
     const receiver = args[2];
-    console.log("receiver", receiver);
     const zrc20 = args[3];
-    console.log("zrc20", zrc20);
     const amount = args[4];
-    console.log("amount", amount);
     const message = args[7];
-    console.log("message", message);
     (tss as NonceManager).reset();
     if (message !== "0x") {
       log("EVM", `Calling ${receiver} with message ${message}`);


### PR DESCRIPTION
Hi guys, 
I think this was just a small mistake here in the way the conditional was created.
The else statement after checking whether there was a message meant that the withdraw part would not execute if there was a message. This doesn't seem like the intention, so I removed the else and just allowed the code to continue after checking for a message and executing the call.
