### PR TITLE
feat: `--exit-on-error` flag

### DIFF
--- a/packages/localnet/src/handleOnEVMCalled.ts
+++ b/packages/localnet/src/handleOnEVMCalled.ts
@@ -12,6 +12,7 @@ export const handleOnEVMCalled = async ({
   deployer,
   fungibleModuleSigner,
   foreignCoins,
+  exitOnError = false,
 }: {
   tss: any;
   provider: ethers.JsonRpcProvider;
@@ -20,6 +21,7 @@ export const handleOnEVMCalled = async ({
   deployer: any;
   fungibleModuleSigner: any;
   foreignCoins: any[];
+  exitOnError: boolean;
 }) => {
   log("EVM", "Gateway: 'Called' event emitted");
   try {
@@ -54,15 +56,16 @@ export const handleOnEVMCalled = async ({
     logs.forEach((data) => {
       log("ZetaChain", `Event from onCrossChainCall: ${JSON.stringify(data)}`);
     });
-  } catch (e: any) {
-    logErr("ZetaChain", `Error executing onCrossChainCall: ${e}`);
+  } catch (err: any) {
+    logErr("ZetaChain", `Error executing onCrossChainCall: ${err}`);
     const revertOptions = args[3];
-    await handleOnRevertEVM({
+    return await handleOnRevertEVM({
       revertOptions,
-      err: e,
+      err,
       tss,
       provider,
       protocolContracts,
+      exitOnError,
     });
   }
 };

--- a/packages/localnet/src/handleOnEVMDeposited.ts
+++ b/packages/localnet/src/handleOnEVMDeposited.ts
@@ -12,6 +12,7 @@ export const handleOnEVMDeposited = async ({
   deployer,
   fungibleModuleSigner,
   foreignCoins,
+  exitOnError = false,
 }: {
   tss: any;
   provider: ethers.JsonRpcProvider;
@@ -20,6 +21,7 @@ export const handleOnEVMDeposited = async ({
   deployer: any;
   fungibleModuleSigner: any;
   foreignCoins: any[];
+  exitOnError: boolean;
 }) => {
   log("EVM", "Gateway: 'Deposited' event emitted");
   try {
@@ -80,15 +82,16 @@ export const handleOnEVMDeposited = async ({
       await tx.wait();
       log("ZetaChain", `Deposited ${amount} of ${zrc20} tokens to ${receiver}`);
     }
-  } catch (e: any) {
-    logErr("ZetaChain", `Error depositing: ${e}`);
+  } catch (err) {
+    logErr("ZetaChain", `Error depositing: ${err}`);
     const revertOptions = args[5];
-    await handleOnRevertEVM({
+    return await handleOnRevertEVM({
       revertOptions,
-      err: e,
+      err,
       tss,
       provider,
       protocolContracts,
+      exitOnError,
     });
   }
 };

--- a/packages/localnet/src/handleOnRevertEVM.ts
+++ b/packages/localnet/src/handleOnRevertEVM.ts
@@ -8,12 +8,14 @@ export const handleOnRevertEVM = async ({
   provider,
   tss,
   protocolContracts,
+  exitOnError = false,
 }: {
   revertOptions: any;
   err: any;
   provider: any;
   tss: any;
   protocolContracts: any;
+  exitOnError: boolean;
 }) => {
   const callOnRevert = revertOptions[1];
   const revertAddress = revertOptions[0];
@@ -45,10 +47,14 @@ export const handleOnRevertEVM = async ({
       logs.forEach((data: any) => {
         log("EVM", `Event from onRevert: ${JSON.stringify(data)}`);
       });
-    } catch (e: any) {
-      logErr("EVM", `Gateway: Call onRevert failed: ${e}`);
+    } catch (err) {
+      const error = `Gateway: Call onRevert failed: ${err}`;
+      logErr("EVM", error);
+      if (exitOnError) throw new Error(error);
     }
   } else {
-    logErr("EVM", `Tx reverted without callOnRevert: ${err}`);
+    const error = `Tx reverted without callOnRevert: ${err}`;
+    logErr("EVM", error);
+    if (exitOnError) throw new Error(error);
   }
 };

--- a/packages/localnet/src/handleOnRevertZEVM.ts
+++ b/packages/localnet/src/handleOnRevertZEVM.ts
@@ -1,13 +1,22 @@
 import { ethers, NonceManager } from "ethers";
 
-export const handleOnRevertZEVM = async (
-  revertOptions: any,
-  err: any,
-  tss: NonceManager,
-  log: (chain: "EVM" | "ZetaChain", ...messages: string[]) => void,
-  protocolContracts: any,
-  deployOpts: any
-) => {
+export const handleOnRevertZEVM = async ({
+  revertOptions,
+  err,
+  tss,
+  log,
+  protocolContracts,
+  deployOpts,
+  exitOnError = false,
+}: {
+  revertOptions: any;
+  err: any;
+  tss: NonceManager;
+  log: (chain: "EVM" | "ZetaChain", ...messages: string[]) => void;
+  protocolContracts: any;
+  deployOpts: any;
+  exitOnError: boolean;
+}) => {
   const callOnRevert = revertOptions[1];
   const revertAddress = revertOptions[0];
   const revertMessage = revertOptions[3];
@@ -25,10 +34,14 @@ export const handleOnRevertZEVM = async (
         .connect(tss)
         .executeRevert(revertAddress, revertContext, deployOpts);
       log("ZetaChain", "Gateway: Call onRevert success");
-    } catch (e) {
-      log("ZetaChain", `Gateway: Call onRevert failed: ${e}`);
+    } catch (err) {
+      const error = `Gateway: Call onRevert failed: ${err}`;
+      log("ZetaChain", error);
+      if (exitOnError) throw new Error(error);
     }
   } else {
-    log("ZetaChain", "Tx reverted without callOnRevert: ", err);
+    const error = `Tx reverted without callOnRevert: ${err}`;
+    log("ZetaChain", error);
+    if (exitOnError) throw new Error(error);
   }
 };

--- a/packages/localnet/src/handleOnZEVMCalled.ts
+++ b/packages/localnet/src/handleOnZEVMCalled.ts
@@ -9,11 +9,13 @@ export const handleOnZEVMCalled = async ({
   provider,
   protocolContracts,
   args,
+  exitOnError = false,
 }: {
   tss: any;
   provider: ethers.JsonRpcProvider;
   protocolContracts: any;
   args: any;
+  exitOnError: boolean;
 }) => {
   log("ZetaChain", "Gateway: 'Called' event emitted");
   try {
@@ -35,15 +37,16 @@ export const handleOnZEVMCalled = async ({
       log("EVM", `Event from contract: ${JSON.stringify(data)}`);
     });
     await executeTx.wait();
-  } catch (e) {
+  } catch (err) {
     const revertOptions = args[5];
-    await handleOnRevertZEVM(
+    return await handleOnRevertZEVM({
       revertOptions,
-      e,
+      err,
       tss,
       log,
       protocolContracts,
-      deployOpts
-    );
+      deployOpts,
+      exitOnError,
+    });
   }
 };

--- a/packages/localnet/src/handleOnZEVMWithdrawn.ts
+++ b/packages/localnet/src/handleOnZEVMWithdrawn.ts
@@ -12,6 +12,7 @@ export const handleOnZEVMWithdrawn = async ({
   args,
   deployer,
   foreignCoins,
+  exitOnError = false,
 }: {
   tss: any;
   provider: ethers.JsonRpcProvider;
@@ -19,6 +20,7 @@ export const handleOnZEVMWithdrawn = async ({
   args: any;
   deployer: any;
   foreignCoins: any[];
+  exitOnError: boolean;
 }) => {
   log("ZetaChain", "Gateway: 'Withdrawn' event emitted");
   try {
@@ -74,15 +76,16 @@ export const handleOnZEVMWithdrawn = async ({
         `Transferred ${amount} ERC-20 tokens from Custody to ${receiver}`
       );
     }
-  } catch (e) {
+  } catch (err) {
     const revertOptions = args[9];
-    await handleOnRevertZEVM(
+    return await handleOnRevertZEVM({
       revertOptions,
-      e,
+      err,
       tss,
       log,
       protocolContracts,
-      deployOpts
-    );
+      deployOpts,
+      exitOnError,
+    });
   }
 };

--- a/packages/localnet/src/index.ts
+++ b/packages/localnet/src/index.ts
@@ -264,7 +264,13 @@ const deployProtocolContracts = async (
   };
 };
 
-export const initLocalnet = async ({ port }: { port: number }) => {
+export const initLocalnet = async ({
+  port,
+  exitOnError,
+}: {
+  port: number;
+  exitOnError: boolean;
+}) => {
   const provider = new ethers.JsonRpcProvider(`http://127.0.0.1:${port}`);
   provider.pollingInterval = 100;
   // anvil test mnemonic
@@ -299,7 +305,7 @@ export const initLocalnet = async ({ port }: { port: number }) => {
 
   // Listen to contracts events
   protocolContracts.gatewayZEVM.on("Called", async (...args: Array<any>) => {
-    handleOnZEVMCalled({ tss, provider, protocolContracts, args });
+    handleOnZEVMCalled({ tss, provider, protocolContracts, args, exitOnError });
   });
 
   protocolContracts.gatewayZEVM.on("Withdrawn", async (...args: Array<any>) => {
@@ -310,11 +316,12 @@ export const initLocalnet = async ({ port }: { port: number }) => {
       args,
       deployer,
       foreignCoins,
+      exitOnError,
     });
   });
 
   protocolContracts.gatewayEVM.on("Called", async (...args: Array<any>) => {
-    handleOnEVMCalled({
+    return await handleOnEVMCalled({
       tss,
       provider,
       protocolContracts,
@@ -322,6 +329,7 @@ export const initLocalnet = async ({ port }: { port: number }) => {
       deployer,
       fungibleModuleSigner,
       foreignCoins,
+      exitOnError,
     });
   });
 
@@ -334,6 +342,7 @@ export const initLocalnet = async ({ port }: { port: number }) => {
       deployer,
       fungibleModuleSigner,
       foreignCoins,
+      exitOnError,
     });
   });
 

--- a/packages/localnet/src/index.ts
+++ b/packages/localnet/src/index.ts
@@ -264,7 +264,7 @@ const deployProtocolContracts = async (
   };
 };
 
-export const initLocalnet = async (port: number) => {
+export const initLocalnet = async ({ port }: { port: number }) => {
   const provider = new ethers.JsonRpcProvider(`http://127.0.0.1:${port}`);
   provider.pollingInterval = 100;
   // anvil test mnemonic

--- a/packages/tasks/src/localnet.ts
+++ b/packages/tasks/src/localnet.ts
@@ -89,7 +89,10 @@ const localnet = async (args: any) => {
   };
 
   try {
-    const addr = await initLocalnet({ port: args.port });
+    const addr = await initLocalnet({
+      port: args.port,
+      exitOnError: args.exitOnError,
+    });
 
     // EVM Contract Addresses
     const evmHeader = "\nEVM Contract Addresses";
@@ -135,7 +138,6 @@ const localnet = async (args: any) => {
 
   const handleExit = (signal: string) => {
     console.log(`\nReceived ${signal}, shutting down...`);
-    cleanup();
     process.exit();
   };
 
@@ -144,6 +146,7 @@ const localnet = async (args: any) => {
 
   process.on("exit", () => {
     console.log("Process exiting...");
+    cleanup();
   });
 
   if (args.stopAfterInit) {
@@ -164,7 +167,5 @@ export const localnetTask = task("localnet", "Start localnet", localnet)
     types.string
   )
   .addFlag("forceKill", "Force kill any process on the port without prompting")
-  .addFlag(
-    "stopAfterInit",
-    "Stop the localnet after successful initialization"
-  );
+  .addFlag("stopAfterInit", "Stop the localnet after successful initialization")
+  .addFlag("exitOnError", "Exit with an error if revert is not handled");

--- a/packages/tasks/src/localnet.ts
+++ b/packages/tasks/src/localnet.ts
@@ -89,7 +89,7 @@ const localnet = async (args: any) => {
   };
 
   try {
-    const addr = await initLocalnet(args.port);
+    const addr = await initLocalnet({ port: args.port });
 
     // EVM Contract Addresses
     const evmHeader = "\nEVM Contract Addresses";

--- a/packages/tasks/src/stop.ts
+++ b/packages/tasks/src/stop.ts
@@ -11,11 +11,23 @@ const localnetStop = async (args: any) => {
   }
 
   const pid = fs.readFileSync(LOCALNET_PID_FILE, "utf-8").trim();
+
   try {
-    process.kill(Number(pid));
-    console.log(ansis.green(`Successfully stopped localnet (PID: ${pid})`));
+    process.kill(Number(pid), 0); // check that the process is running
+    try {
+      process.kill(Number(pid));
+      console.log(ansis.green(`Successfully stopped localnet (PID: ${pid})`));
+    } catch (err) {
+      console.error(ansis.red(`Failed to stop localnet: ${err}`));
+    }
   } catch (err) {
-    console.error(ansis.red(`Failed to stop localnet: ${err}`));
+    console.log(ansis.yellow(`Localnet process (PID: ${pid}) is not running.`));
+    try {
+      fs.unlinkSync(LOCALNET_PID_FILE);
+      console.log(ansis.green("Localnet PID file deleted."));
+    } catch (err) {
+      console.error(ansis.red(`Failed to delete PID file: ${err}`));
+    }
   }
 };
 

--- a/packages/tasks/src/stop.ts
+++ b/packages/tasks/src/stop.ts
@@ -14,8 +14,6 @@ const localnetStop = async (args: any) => {
   try {
     process.kill(Number(pid));
     console.log(ansis.green(`Successfully stopped localnet (PID: ${pid})`));
-    fs.unlinkSync(LOCALNET_PID_FILE);
-    console.log(ansis.green(`PID file ${LOCALNET_PID_FILE} removed.`));
   } catch (err) {
     console.error(ansis.red(`Failed to stop localnet: ${err}`));
   }


### PR DESCRIPTION
* `--exit-on-error` flag to kill localnet if revert fails or tx reverted without call on revert. This could be useful in CI, where you want localnet to fail if something goes wrong
* refactored the stop task to remove `localnet.pid` if if exists, but the localnet is not running (it cannot cleanup after itself and delete pid if it's not running)