### PR TITLE
Fix revert handling

### DIFF
--- a/packages/localnet/src/createToken.ts
+++ b/packages/localnet/src/createToken.ts
@@ -98,7 +98,7 @@ export const createToken = async ({
 
   foreignCoins.push({
     zrc20_contract_address: zrc20.target,
-    asset: isGasToken ? "" : (erc20 as any).target,
+    asset: isGasToken ? ethers.ZeroAddress : (erc20 as any).target,
     foreign_chain_id: "1",
     decimals: 18,
     name: `ZetaChain ZRC-20 ${symbol}`,

--- a/packages/localnet/src/createToken.ts
+++ b/packages/localnet/src/createToken.ts
@@ -98,7 +98,7 @@ export const createToken = async ({
 
   foreignCoins.push({
     zrc20_contract_address: zrc20.target,
-    asset: isGasToken ? ethers.ZeroAddress : (erc20 as any).target,
+    asset: isGasToken ? "" : (erc20 as any).target,
     foreign_chain_id: "1",
     decimals: 18,
     name: `ZetaChain ZRC-20 ${symbol}`,

--- a/packages/localnet/src/handleOnEVMCalled.ts
+++ b/packages/localnet/src/handleOnEVMCalled.ts
@@ -62,6 +62,8 @@ export const handleOnEVMCalled = async ({
     return await handleOnRevertEVM({
       revertOptions,
       err,
+      amount: 0,
+      asset: ethers.ZeroAddress,
       tss,
       provider,
       protocolContracts,

--- a/packages/localnet/src/handleOnEVMCalled.ts
+++ b/packages/localnet/src/handleOnEVMCalled.ts
@@ -65,6 +65,8 @@ export const handleOnEVMCalled = async ({
       amount: 0,
       asset: ethers.ZeroAddress,
       tss,
+      isGas: true,
+      token: "",
       provider,
       protocolContracts,
       exitOnError,

--- a/packages/localnet/src/handleOnEVMDeposited.ts
+++ b/packages/localnet/src/handleOnEVMDeposited.ts
@@ -97,7 +97,6 @@ export const handleOnEVMDeposited = async ({
       token = foreignCoins.find(
         (coin) => coin.zrc20_contract_address === zrc20
       )?.asset;
-      console.log("token!", token);
       isGas = false;
       const uniswapV2Router = new ethers.Contract(
         protocolContracts.uniswapRouterInstance.target,

--- a/packages/localnet/src/handleOnEVMDeposited.ts
+++ b/packages/localnet/src/handleOnEVMDeposited.ts
@@ -3,6 +3,7 @@ import { handleOnRevertEVM } from "./handleOnRevertEVM";
 import { log, logErr } from "./log";
 import { deployOpts } from "./deployOpts";
 import * as ZRC20 from "@zetachain/protocol-contracts/abi/ZRC20.sol/ZRC20.json";
+import * as UniswapV2Router02 from "@uniswap/v2-periphery/build/UniswapV2Router02.json";
 
 // event Deposited(address indexed sender, address indexed receiver, uint256 amount, address asset, bytes payload, RevertOptions revertOptions);
 export const handleOnEVMDeposited = async ({
@@ -88,16 +89,119 @@ export const handleOnEVMDeposited = async ({
     const [gasZRC20, gasFee] = await zrc20Contract.withdrawGasFeeWithGasLimit(
       revertOptions[4]
     );
-    const amountReverted = amount - gasFee;
+    let revertAmount;
+    let revertGasFee = gasFee;
+    let isGas = true;
+    let token = null;
+    if (zrc20 !== gasZRC20) {
+      token = foreignCoins.find(
+        (coin) => coin.zrc20_contract_address === zrc20
+      )?.asset;
+      console.log("token!", token);
+      isGas = false;
+      const uniswapV2Router = new ethers.Contract(
+        protocolContracts.uniswapRouterInstance.target,
+        UniswapV2Router02.abi,
+        deployer
+      );
+      deployer.reset();
+      const approvalTx = await zrc20Contract.approve(
+        protocolContracts.uniswapRouterInstance.target,
+        amount
+      );
+      await approvalTx.wait();
+
+      const path = [zrc20, protocolContracts.wzeta.target, gasZRC20];
+
+      const deadline = Math.floor(Date.now() / 1000) + 60 * 20;
+      const maxZRC20ToSpend = amount;
+
+      try {
+        const swapTx = await uniswapV2Router.swapTokensForExactTokens(
+          gasFee,
+          maxZRC20ToSpend,
+          path,
+          await fungibleModuleSigner.getAddress(),
+          deadline
+        );
+
+        const amountInZeta = await getAmounts(
+          "in",
+          provider,
+          gasFee,
+          protocolContracts.wzeta.target,
+          gasZRC20,
+          protocolContracts.uniswapRouterInstance.target,
+          UniswapV2Router02
+        );
+
+        const amountInZRC20 = await getAmounts(
+          "in",
+          provider,
+          amountInZeta[0],
+          zrc20,
+          protocolContracts.wzeta.target,
+          protocolContracts.uniswapRouterInstance.target,
+          UniswapV2Router02
+        );
+
+        revertGasFee = amountInZRC20[0];
+
+        await swapTx.wait();
+      } catch (swapError) {
+        logErr("ZetaChain", `Error performing swap on Uniswap: ${swapError}`);
+      }
+    }
+    revertAmount = amount - revertGasFee;
     return await handleOnRevertEVM({
       revertOptions,
       asset,
-      amount: amountReverted,
+      amount: revertAmount,
       err,
       tss,
+      isGas,
+      token: "",
       provider,
       protocolContracts,
       exitOnError,
     });
   }
+};
+
+/**
+ * Retrieves the amounts for swapping tokens using UniswapV2.
+ * @param {"in" | "out"} direction - The direction of the swap ("in" or "out").
+ * @param {any} provider - The ethers provider.
+ * @param {any} amount - The amount to swap.
+ * @param {string} tokenA - The address of token A.
+ * @param {string} tokenB - The address of token B.
+ * @returns {Promise<any>} - The amounts for the swap.
+ * @throws Will throw an error if the UniswapV2 router address cannot be retrieved.
+ */
+const getAmounts = async (
+  direction: "in" | "out",
+  provider: any,
+  amount: any,
+  tokenA: string,
+  tokenB: string,
+  routerAddress: any,
+  routerABI: any
+) => {
+  if (!routerAddress) {
+    throw new Error("Cannot get uniswapV2Router02 address");
+  }
+
+  const uniswapRouter = new ethers.Contract(
+    routerAddress,
+    routerABI.abi,
+    provider
+  );
+
+  const path = [tokenA, tokenB];
+
+  const amounts =
+    direction === "in"
+      ? await uniswapRouter.getAmountsIn(amount, path)
+      : await uniswapRouter.getAmountsOut(amount, path);
+  return amounts;
 };

--- a/packages/localnet/src/handleOnEVMDeposited.ts
+++ b/packages/localnet/src/handleOnEVMDeposited.ts
@@ -24,12 +24,11 @@ export const handleOnEVMDeposited = async ({
   exitOnError: boolean;
 }) => {
   log("EVM", "Gateway: 'Deposited' event emitted");
+  const receiver = args[1];
+  const amount = args[2];
+  const asset = args[3];
+  const message = args[4];
   try {
-    const receiver = args[1];
-    const amount = args[2];
-    const asset = args[3];
-    const message = args[4];
-
     let foreignCoin;
     if (asset === ethers.ZeroAddress) {
       foreignCoin = foreignCoins.find((coin) => coin.coin_type === "Gas");
@@ -87,6 +86,8 @@ export const handleOnEVMDeposited = async ({
     const revertOptions = args[5];
     return await handleOnRevertEVM({
       revertOptions,
+      asset,
+      amount,
       err,
       tss,
       provider,

--- a/packages/localnet/src/handleOnEVMDeposited.ts
+++ b/packages/localnet/src/handleOnEVMDeposited.ts
@@ -160,7 +160,7 @@ export const handleOnEVMDeposited = async ({
       err,
       tss,
       isGas,
-      token: "",
+      token,
       provider,
       protocolContracts,
       exitOnError,

--- a/packages/localnet/src/handleOnRevertEVM.ts
+++ b/packages/localnet/src/handleOnRevertEVM.ts
@@ -26,7 +26,7 @@ export const handleOnRevertEVM = async ({
   const revertMessage = revertOptions[3];
   const revertContext = {
     asset,
-    amount, // this should deduct the gas costs
+    amount,
     revertMessage,
   };
   if (callOnRevert) {

--- a/packages/localnet/src/handleOnRevertEVM.ts
+++ b/packages/localnet/src/handleOnRevertEVM.ts
@@ -4,6 +4,8 @@ import { ethers, NonceManager } from "ethers";
 
 export const handleOnRevertEVM = async ({
   revertOptions,
+  asset,
+  amount,
   err,
   provider,
   tss,
@@ -12,6 +14,8 @@ export const handleOnRevertEVM = async ({
 }: {
   revertOptions: any;
   err: any;
+  asset: any;
+  amount: any;
   provider: any;
   tss: any;
   protocolContracts: any;
@@ -21,8 +25,8 @@ export const handleOnRevertEVM = async ({
   const revertAddress = revertOptions[0];
   const revertMessage = revertOptions[3];
   const revertContext = {
-    asset: ethers.ZeroAddress,
-    amount: 0,
+    asset,
+    amount, // this should deduct the gas costs
     revertMessage,
   };
   if (callOnRevert) {

--- a/packages/localnet/src/handleOnRevertEVM.ts
+++ b/packages/localnet/src/handleOnRevertEVM.ts
@@ -44,7 +44,6 @@ export const handleOnRevertEVM = async ({
       (tss as NonceManager).reset();
       let tx;
       if (isGas) {
-        console.log(protocolContracts.gatewayEVM.connect(tss).functions);
         tx = await protocolContracts.gatewayEVM
           .connect(tss)
           .executeRevert(revertAddress, "0x", revertContext, {

--- a/packages/localnet/src/handleOnRevertEVM.ts
+++ b/packages/localnet/src/handleOnRevertEVM.ts
@@ -52,22 +52,13 @@ export const handleOnRevertEVM = async ({
             deployOpts,
           });
       } else {
-        console.log(
-          "!!!",
-          revertAddress,
-          token,
-          amount,
-          "0x",
-          revertContext,
-          deployOpts
-        );
-        tx = await protocolContracts.custody // this is failing
+        tx = await protocolContracts.custody
           .connect(tss)
           .withdrawAndRevert(
             revertAddress,
             token,
             amount,
-            "",
+            "0x",
             revertContext,
             deployOpts
           );

--- a/packages/localnet/src/handleOnRevertZEVM.ts
+++ b/packages/localnet/src/handleOnRevertZEVM.ts
@@ -4,6 +4,8 @@ import { logErr } from "./log";
 export const handleOnRevertZEVM = async ({
   revertOptions,
   err,
+  asset,
+  amount,
   provider,
   tss,
   log,
@@ -14,6 +16,8 @@ export const handleOnRevertZEVM = async ({
 }: {
   revertOptions: any;
   err: any;
+  asset: any;
+  amount: any;
   provider: any;
   fungibleModuleSigner: any;
   tss: NonceManager;
@@ -26,8 +30,8 @@ export const handleOnRevertZEVM = async ({
   const revertAddress = revertOptions[0];
   const revertMessage = revertOptions[3];
   const revertContext = {
-    asset: ethers.ZeroAddress,
-    amount: 0,
+    asset,
+    amount,
     revertMessage,
   };
 

--- a/packages/localnet/src/handleOnZEVMCalled.ts
+++ b/packages/localnet/src/handleOnZEVMCalled.ts
@@ -45,6 +45,8 @@ export const handleOnZEVMCalled = async ({
     return await handleOnRevertZEVM({
       revertOptions,
       err,
+      amount: 0,
+      asset: ethers.ZeroAddress,
       provider,
       fungibleModuleSigner,
       tss,

--- a/packages/localnet/src/handleOnZEVMWithdrawn.ts
+++ b/packages/localnet/src/handleOnZEVMWithdrawn.ts
@@ -55,7 +55,6 @@ export const handleOnZEVMWithdrawn = async ({
         await executeTx.wait();
       } else {
         const erc20 = getERC20ByZRC20(zrc20);
-        console.log("!!!", receiver, erc20, amount, message, deployOpts);
         const executeTx = await protocolContracts.custody
           .connect(tss)
           .withdrawAndCall(receiver, erc20, amount, message, deployOpts);

--- a/packages/localnet/src/handleOnZEVMWithdrawn.ts
+++ b/packages/localnet/src/handleOnZEVMWithdrawn.ts
@@ -55,6 +55,7 @@ export const handleOnZEVMWithdrawn = async ({
         await executeTx.wait();
       } else {
         const erc20 = getERC20ByZRC20(zrc20);
+        console.log("!!!", receiver, erc20, amount, message, deployOpts);
         const executeTx = await protocolContracts.custody
           .connect(tss)
           .withdrawAndCall(receiver, erc20, amount, message, deployOpts);

--- a/packages/localnet/src/index.ts
+++ b/packages/localnet/src/index.ts
@@ -20,6 +20,11 @@ const FUNGIBLE_MODULE_ADDRESS = "0x735b14BB79463307AAcBED86DAf3322B1e6226aB";
 
 const foreignCoins: any[] = [];
 
+// A hack to make BigInt serializable
+(BigInt as any).prototype["toJSON"] = function () {
+  return this.toString();
+};
+
 let protocolContracts: any;
 let deployer: Signer;
 let tss: Signer;
@@ -195,7 +200,6 @@ const deployProtocolContracts = async (
 
   const { uniswapFactoryInstance, uniswapRouterInstance } =
     await prepareUniswap(deployer, tss, wzeta);
-
   const { systemContract, gatewayZEVM } = await prepareZetaChain(
     deployer,
     wzeta.target,

--- a/packages/tasks/src/localnet.ts
+++ b/packages/tasks/src/localnet.ts
@@ -121,6 +121,7 @@ const localnet = async (args: any) => {
       ZETA: addr.zetaZetaChain,
       "Fungible Module": addr.fungibleModuleZetaChain,
       "System Contract": addr.sytemContractZetaChain,
+      "Uniswap Router": addr.uniswapRouter,
       ...addr.foreignCoins.reduce((acc: any, coin: any) => {
         acc[`ZRC-20 ${coin.symbol}`] = coin.zrc20_contract_address;
         return acc;


### PR DESCRIPTION
- [x] Revert context now contains correct data
- [x] Revert amount on EVM should take into account the revert call gas costs

```
npx hardhat localnet
```

Using [the Hello example](https://github.com/zeta-chain/example-contracts/tree/893d2bf110e33780659d2bc470868aec4017dc27/examples/hello):

```
yarn deploy
```

The Hello contract expects a string, so we're sending a uint256 to simulate a revert. Passing 1*10^18 ERC-20, and getting `999999999992957809`, which is the amount minus the withdraw gas costs

```
npx hardhat evm-deposit-and-call --amount 1 --receiver 0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E --network localhost --revert-address 0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690 --erc20 0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82 --call-on-revert --types '["uint256"]' 42
```

With gas we're getting back 999999999993000000:

```
npx hardhat evm-deposit-and-call --amount 1 --receiver 0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E --network localhost --revert-address 0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690 --call-on-revert --types '["uint256"]' 42
Transaction hash: 0x61b006f1294e5b8a02b86bda86b99b3379766d4f9058d3070a0e020c418c7214
```

The actual gas costs is 7000000, but with ERC-20 we're getting less, because we're swapping, even though the exchange is 1:1 we're getting slightly less.