### PR TITLE
ci: publish releases to Discord

### DIFF
--- a/.github/workflows/release-to-discord.yml
+++ b/.github/workflows/release-to-discord.yml
@@ -1,0 +1,21 @@
+on:
+  release:
+    types: [published]
+
+jobs:
+  github-releases-to-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Github Releases To Discord
+        uses: SethCohen/github-releases-to-discord@v1
+        with:
+          webhook_url: ${{ secrets.WEBHOOK_URL }}
+          color: "2105893"
+          username: "Release Changelog"
+          content: "||@everyone||"
+          footer_title: "Changelog"
+          footer_timestamp: true
+          max_description: "4096"
+          reduce_headings: true


### PR DESCRIPTION
Automatically publish release information to a Discord channel. The channel is temporarily private until this works as expected.