### PR TITLE
Task to check if localnet is still running for CI

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,5 +1,6 @@
 import "./packages/tasks/src/localnet";
 import "./packages/tasks/src/stop";
+import "./packages/tasks/src/check";
 
 import { HardhatUserConfig } from "hardhat/config";
 

--- a/packages/tasks/src/check.ts
+++ b/packages/tasks/src/check.ts
@@ -1,0 +1,32 @@
+import { task, types } from "hardhat/config";
+import fs from "fs";
+import ansis from "ansis";
+
+const LOCALNET_PID_FILE = "./localnet.pid";
+
+const localnetCheck = async (args: any) => {
+  await new Promise((resolve) => setTimeout(resolve, args.delay * 1000));
+
+  if (!fs.existsSync(LOCALNET_PID_FILE)) {
+    console.log(ansis.red("Localnet is not running (PID file missing)."));
+    process.exit(1);
+  }
+
+  const pid = fs.readFileSync(LOCALNET_PID_FILE, "utf-8").trim();
+
+  try {
+    process.kill(Number(pid), 0);
+    console.log(ansis.green(`Localnet is running (PID: ${pid}).`));
+    process.exit(0);
+  } catch (err) {
+    console.log(ansis.yellow(`Localnet process (PID: ${pid}) is not running.`));
+    process.exit(1);
+  }
+};
+
+export const localnetCheckTask = task(
+  "localnet-check",
+  "Check if localnet is running"
+)
+  .addParam("delay", "Seconds to wait before checking localnet", 3, types.int)
+  .setAction(localnetCheck);

--- a/packages/tasks/src/index.ts
+++ b/packages/tasks/src/index.ts
@@ -1,2 +1,3 @@
 export { localnetTask } from "./localnet";
 export { localnetStopTask } from "./stop";
+export { localnetCheckTask } from "./check";


### PR DESCRIPTION
A task to check if `localnet` is still running. Useful for CI for testing example contracts:

```
#!/bin/bash

set -e

npx hardhat localnet --exit-on-error &

sleep 5

yarn deploy

npx hardhat echo-call \
  --contract 0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690 \
  --receiver 0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E \
  --network localhost \
  --types '["string"]' alice

npx hardhat localnet-check

npx hardhat echo-call \
  --contract 0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690 \
  --receiver 0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E \
  --network localhost \
  --types '["uint256"]' 42

npx hardhat localnet-check
```

By default runs with a delay of 3 seconds to let a call finish.