### PR TITLE
Release to Discord: update image URL

### DIFF
--- a/.github/workflows/release-to-discord.yml
+++ b/.github/workflows/release-to-discord.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   github-releases-to-discord:
+    if: "! contains(github.event.release.tag_name, '-')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release-to-discord.yml
+++ b/.github/workflows/release-to-discord.yml
@@ -13,9 +13,7 @@ jobs:
         with:
           webhook_url: ${{ secrets.WEBHOOK_URL }}
           color: "2105893"
-          username: "Release Changelog"
-          content: "||@everyone||"
-          footer_title: "Changelog"
-          footer_timestamp: true
+          username: "New Release: Localnet"
           max_description: "4096"
           reduce_headings: true
+          avatar_url: "https://raw.githubusercontent.com/zeta-chain/docs/refs/heads/main/public/img/icons/zetachain/square/white-on-green.png"


### PR DESCRIPTION
Added an avatar image, removed extra properties.

<img width="716" alt="Screenshot 2024-10-22 at 11 26 44" src="https://github.com/user-attachments/assets/f2c69dc3-25a7-46ed-94c2-e2b78387370b">

Also, don't publish releases with `-` in name (release candidates like `v1.0.0-rc1`).