### PR TITLE
Make localnet compatible with Gateway deployed on testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,54 +3,5 @@
 Localnet is a local development environment that simplifies the development of
 universal apps.
 
-Localnet:
-
-- Starts an [Anvil](https://book.getfoundry.sh/anvil/) local testnet node
-- Deploys [protocol
-  contracts](https://github.com/zeta-chain/protocol-contracts/tree/main/v2) on
-  the local testnet node. Both EVM gateway and ZetaChain gateway are deployed
-  and running on the same local blockchain
-- Simulates the real-world testnet environment of ZetaChain by observing events
-  and relaying the contract calls between EVM gateway and ZetaChain gateway
-
-Install dependencies:
-
-```
-yarn
-```
-
-Start localnet:
-
-```
-yarn hardhat localnet
-```
-
-```
-EVM Contract Addresses
-=======================
-┌─────────────────┬──────────────────────────────────────────────┐
-│   Gateway EVM   │ '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0' │
-│ ERC-20 Custody  │ '0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9' │
-│       TSS       │ '0x70997970C51812dc3A010C7d01b50e0d17dc79C8' │
-│      ZETA       │ '0x5FbDB2315678afecb367f032d93F642f64180aa3' │
-│ ERC-20 USDC.ETH │ '0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82' │
-└─────────────────┴──────────────────────────────────────────────┘
-
-ZetaChain Contract Addresses
-=============================
-┌───────────────────┬──────────────────────────────────────────────┐
-│ Gateway ZetaChain │ '0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0' │
-│       ZETA        │ '0xa513E6E4b8f2a923D98304ec87F64353C4D5C853' │
-│  Fungible Module  │ '0x735b14BB79463307AAcBED86DAf3322B1e6226aB' │
-│  System Contract  │ '0x610178dA211FEF7D417bC0e6FeD39F05609AD788' │
-│  ZRC-20 USDC.ETH  │ '0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c' │
-│  ZRC-20 ETH.ETH   │ '0x2ca7d64A7EFE2D62A725E2B35Cf7230D6677FfEe' │
-└───────────────────┴──────────────────────────────────────────────┘
-```
-
-You can also start localnet with custom Anvil parameters and using a different
-port:
-
-```
-yarn hardhat localnet --anvil "--block-time 1" --port 2000
-```
+Learn more about localnet:
+https://www.zetachain.com/docs/developers/tutorials/localnet/

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@inquirer/prompts": "^5.5.0",
     "@uniswap/v2-core": "^1.0.1",
     "@uniswap/v2-periphery": "^1.1.0-beta.0",
-    "@zetachain/protocol-contracts": "10.0.0-rc10",
+    "@zetachain/protocol-contracts": "10.0.0-rc11",
     "ansis": "^3.3.2",
     "concurrently": "^8.2.2",
     "ethers": "^6.13.2",

--- a/packages/localnet/src/handleOnEVMCalled.ts
+++ b/packages/localnet/src/handleOnEVMCalled.ts
@@ -40,7 +40,7 @@ export const handleOnEVMCalled = async ({
 
     log(
       "ZetaChain",
-      `Universal contract ${receiver} executing onCrossChainCall (context: ${JSON.stringify(
+      `Universal contract ${receiver} executing onCall (context: ${JSON.stringify(
         context
       )}), zrc20: ${zrc20}, amount: 0, message: ${message})`
     );
@@ -54,10 +54,10 @@ export const handleOnEVMCalled = async ({
     });
 
     logs.forEach((data) => {
-      log("ZetaChain", `Event from onCrossChainCall: ${JSON.stringify(data)}`);
+      log("ZetaChain", `Event from onCall: ${JSON.stringify(data)}`);
     });
   } catch (err: any) {
-    logErr("ZetaChain", `Error executing onCrossChainCall: ${err}`);
+    logErr("ZetaChain", `Error executing onCall: ${err}`);
     const revertOptions = args[3];
     return await handleOnRevertEVM({
       revertOptions,

--- a/packages/localnet/src/handleOnEVMDeposited.ts
+++ b/packages/localnet/src/handleOnEVMDeposited.ts
@@ -54,7 +54,7 @@ export const handleOnEVMDeposited = async ({
     if (message !== "0x") {
       log(
         "ZetaChain",
-        `Universal contract ${receiver} executing onCrossChainCall (context: ${JSON.stringify(
+        `Universal contract ${receiver} executing onCall (context: ${JSON.stringify(
           context
         )}), zrc20: ${zrc20}, amount: ${amount}, message: ${message})`
       );
@@ -70,10 +70,7 @@ export const handleOnEVMDeposited = async ({
       });
 
       logs.forEach((data) => {
-        log(
-          "ZetaChain",
-          `Event from onCrossChainCall: ${JSON.stringify(data)}`
-        );
+        log("ZetaChain", `Event from onCall: ${JSON.stringify(data)}`);
       });
     } else {
       const tx = await protocolContracts.gatewayZEVM

--- a/yarn.lock
+++ b/yarn.lock
@@ -632,14 +632,14 @@
     "@nomicfoundation/solidity-analyzer-win32-x64-msvc" "0.1.2"
 
 "@openzeppelin/contracts-upgradeable@^5.0.2":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.0.2.tgz#3e5321a2ecdd0b206064356798c21225b6ec7105"
-  integrity sha512-0MmkHSHiW2NRFiT9/r5Lu4eJq5UJ4/tzlOgYXNAIj/ONkQTVnz22pLxDvp4C4uZ9he7ZFvGn3Driptn1/iU7tQ==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.1.0.tgz#4d37648b7402929c53e2ff6e45749ecff91eb2b6"
+  integrity sha512-AIElwP5Ck+cslNE+Hkemf5SxjJoF4wBvvjxc27Rp+9jaPs/CLIaUBMYe1FNzhdiN0cYuwGRmYaRHmmntuiju4Q==
 
 "@openzeppelin/contracts@^5.0.2":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.0.2.tgz#b1d03075e49290d06570b2fd42154d76c2a5d210"
-  integrity sha512-ytPc6eLGcHHnapAZ9S+5qsdomhjo6QBHTDRRBFfTxXIpsicMhVPouPgmUPebZZZGX7vt9USA+Z+0M0dSVtSUEA==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.1.0.tgz#4e61162f2a2bf414c4e10c45eca98ce5f1aadbd4"
+  integrity sha512-p1ULhl7BXzjjbha5aqst+QMLY+4/LCWADXOCsmLHRM77AqiPjnd9vvUN9sosUfhL9JGKpZ0TjEGxgvnizmWGSA==
 
 "@scure/base@~1.1.0":
   version "1.1.7"
@@ -811,6 +811,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.13.tgz#f64277c341150c979e42b00e4ac289290c9df469"
   integrity sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==
 
+"@types/node@22.7.5":
+  version "22.7.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.5.tgz#cfde981727a7ab3611a481510b473ae54442b92b"
+  integrity sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==
+  dependencies:
+    undici-types "~6.19.2"
+
 "@types/node@^22.5.2":
   version "22.5.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.4.tgz#83f7d1f65bc2ed223bdbf57c7884f1d5a4fa84e8"
@@ -953,13 +960,21 @@
     "@uniswap/lib" "1.1.1"
     "@uniswap/v2-core" "1.0.0"
 
-"@zetachain/protocol-contracts@10.0.0-rc10":
-  version "10.0.0-rc10"
-  resolved "https://registry.yarnpkg.com/@zetachain/protocol-contracts/-/protocol-contracts-10.0.0-rc10.tgz#e3c21b493904ec743c9026627b2f809009fec7a2"
-  integrity sha512-kOH7Lk0os3xt9N/FCdeaLUMyonfez97q69Jy2YFwddjv9jpqaxwLXWj2hvdIFc21inKZ7HIjmDDcj9/n8gITKg==
+"@zetachain/networks@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@zetachain/networks/-/networks-10.0.0.tgz#dd5d14a0870f6b658644aded8c96859f15531089"
+  integrity sha512-FPolaO19oVkSLSPDUA/Hu+8AhG3lDEslRDpLnMzbMbnNSC669Fkah0/TEf+6egrQbAifBRfFLzwWidAGs8oxtA==
+  dependencies:
+    dotenv "^16.1.4"
+
+"@zetachain/protocol-contracts@10.0.0-rc11":
+  version "10.0.0-rc11"
+  resolved "https://registry.yarnpkg.com/@zetachain/protocol-contracts/-/protocol-contracts-10.0.0-rc11.tgz#53f55ead492f7b5802b1feae4e51abc75730af33"
+  integrity sha512-qWazjqnIGRngf4OmyeSIv7sHICQRdMQ1CKPIQIqxA8qFR+gHhDHSfvMdRAvgWbsfkimXOIFiHVIATypyWhviJw==
   dependencies:
     "@openzeppelin/contracts" "^5.0.2"
     "@openzeppelin/contracts-upgradeable" "^5.0.2"
+    "@zetachain/networks" "^10.0.0"
     ethers "^6.13.1"
 
 acorn-jsx@^5.3.2:
@@ -1537,6 +1552,11 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+dotenv@^16.1.4:
+  version "16.4.5"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
+  integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
+
 elliptic@6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
@@ -1751,7 +1771,20 @@ ethereumjs-util@^6.0.0, ethereumjs-util@^6.2.1:
     ethjs-util "0.1.6"
     rlp "^2.2.3"
 
-ethers@^6.13.1, ethers@^6.13.2:
+ethers@^6.13.1:
+  version "6.13.4"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.13.4.tgz#bd3e1c3dc1e7dc8ce10f9ffb4ee40967a651b53c"
+  integrity sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==
+  dependencies:
+    "@adraffy/ens-normalize" "1.10.1"
+    "@noble/curves" "1.2.0"
+    "@noble/hashes" "1.3.2"
+    "@types/node" "22.7.5"
+    aes-js "4.0.0-beta.5"
+    tslib "2.7.0"
+    ws "8.17.1"
+
+ethers@^6.13.2:
   version "6.13.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.13.2.tgz#4b67d4b49e69b59893931a032560999e5e4419fe"
   integrity sha512-9VkriTTed+/27BGuY1s0hf441kqwHJ1wtN2edksEtiRvXx+soxRX3iSXTfFqq2+YwrOqbDoTHjIhQnjJRlzKmg==
@@ -3194,6 +3227,11 @@ tslib@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
+tslib@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
+  integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
 tslib@^1.9.3:
   version "1.14.1"


### PR DESCRIPTION
After this is merged, release a new `v3.*.*` version of localnet from main to npm and update bump the version of localnet in https://github.com/zeta-chain/example-contracts/pull/207