### PR TITLE
Use `localnet.json` containing both PID and addresses

### DIFF
--- a/packages/tasks/src/check.ts
+++ b/packages/tasks/src/check.ts
@@ -2,17 +2,18 @@ import { task, types } from "hardhat/config";
 import fs from "fs";
 import ansis from "ansis";
 
-const LOCALNET_PID_FILE = "./localnet.pid";
+const LOCALNET_JSON_FILE = "./localnet.json";
 
 const localnetCheck = async (args: any) => {
   await new Promise((resolve) => setTimeout(resolve, args.delay * 1000));
 
-  if (!fs.existsSync(LOCALNET_PID_FILE)) {
-    console.log(ansis.red("Localnet is not running (PID file missing)."));
+  if (!fs.existsSync(LOCALNET_JSON_FILE)) {
+    console.log(ansis.red("Localnet is not running (JSON file missing)."));
     process.exit(1);
   }
 
-  const pid = fs.readFileSync(LOCALNET_PID_FILE, "utf-8").trim();
+  const jsonData = JSON.parse(fs.readFileSync(LOCALNET_JSON_FILE, "utf-8"));
+  const pid = jsonData.pid;
 
   try {
     process.kill(Number(pid), 0);

--- a/packages/tasks/src/localnet.ts
+++ b/packages/tasks/src/localnet.ts
@@ -6,7 +6,7 @@ import ansis from "ansis";
 import fs from "fs";
 import { confirm } from "@inquirer/prompts";
 
-const LOCALNET_PID_FILE = "./localnet.pid";
+const LOCALNET_JSON_FILE = "./localnet.json";
 
 const killProcessOnPort = async (port: number, forceKill: boolean) => {
   try {
@@ -83,8 +83,8 @@ const localnet = async (args: any) => {
     if (anvilProcess) {
       anvilProcess.kill();
     }
-    if (fs.existsSync(LOCALNET_PID_FILE)) {
-      fs.unlinkSync(LOCALNET_PID_FILE);
+    if (fs.existsSync(LOCALNET_JSON_FILE)) {
+      fs.unlinkSync(LOCALNET_JSON_FILE);
     }
   };
 
@@ -130,7 +130,11 @@ const localnet = async (args: any) => {
 
     console.table(zetaAddresses);
 
-    fs.writeFileSync(LOCALNET_PID_FILE, process.pid.toString(), "utf-8");
+    fs.writeFileSync(
+      LOCALNET_JSON_FILE,
+      JSON.stringify({ pid: process.pid, addresses: addr }, null, 2),
+      "utf-8"
+    );
   } catch (error: any) {
     console.error(ansis.red`Error initializing localnet: ${error}`);
     cleanup();

--- a/packages/tasks/src/stop.ts
+++ b/packages/tasks/src/stop.ts
@@ -2,15 +2,16 @@ import { task } from "hardhat/config";
 import fs from "fs";
 import ansis from "ansis";
 
-const LOCALNET_PID_FILE = "./localnet.pid";
+const LOCALNET_JSON_FILE = "./localnet.json";
 
 const localnetStop = async (args: any) => {
-  if (!fs.existsSync(LOCALNET_PID_FILE)) {
-    console.log(ansis.red("Localnet is not running or PID file is missing."));
+  if (!fs.existsSync(LOCALNET_JSON_FILE)) {
+    console.log(ansis.red("Localnet is not running or JSON file is missing."));
     return;
   }
 
-  const pid = fs.readFileSync(LOCALNET_PID_FILE, "utf-8").trim();
+  const jsonData = JSON.parse(fs.readFileSync(LOCALNET_JSON_FILE, "utf-8"));
+  const pid = jsonData.pid;
 
   try {
     process.kill(Number(pid), 0); // check that the process is running
@@ -23,10 +24,10 @@ const localnetStop = async (args: any) => {
   } catch (err) {
     console.log(ansis.yellow(`Localnet process (PID: ${pid}) is not running.`));
     try {
-      fs.unlinkSync(LOCALNET_PID_FILE);
-      console.log(ansis.green("Localnet PID file deleted."));
+      fs.unlinkSync(LOCALNET_JSON_FILE);
+      console.log(ansis.green("Localnet JSON file deleted."));
     } catch (err) {
-      console.error(ansis.red(`Failed to delete PID file: ${err}`));
+      console.error(ansis.red(`Failed to delete JSON file: ${err}`));
     }
   }
 };


### PR DESCRIPTION
Write both PID and contract addresses to `localnet.json`. Addresses can be used in automated tests so that if localnet addresses change, tests will still be able to read the correct addresses from the JSON.

Basically, to avoid hard-coding them:

https://github.com/zeta-chain/example-contracts/blob/31fb966047a9d73a6ecedc91c8b7f455ef1297c2/examples/nft/scripts/test.sh#L24-L28

For example, https://github.com/zeta-chain/example-contracts/pull/212