### PR TITLE
fix: call evmExecute with gas tokens, Solana improvements

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -28,24 +28,6 @@ jobs:
       - name: Install Anchor (Solana)
         uses: metadaoproject/setup-anchor@v3.1
 
-      - name: Cache Sui CLI
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: sui-cli-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            sui-cli-${{ runner.os }}-
-
-      - name: Install Sui CLI
-        run: |
-          if ! command -v sui &> /dev/null; then
-            cargo install --locked --git https://github.com/MystenLabs/sui.git --branch main sui
-          fi
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
       - name: Install Dependencies
         run: yarn
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
+      - name: Install Anchor (Solana)
+        uses: metadaoproject/setup-anchor@v3.1
+
       - name: Install Dependencies
         run: yarn
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -28,10 +28,23 @@ jobs:
       - name: Install Anchor (Solana)
         uses: metadaoproject/setup-anchor@v3.1
 
+      - name: Cache Sui CLI
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: sui-cli-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            sui-cli-${{ runner.os }}-
+
       - name: Install Sui CLI
         run: |
-          cargo install --locked --git https://github.com/MystenLabs/sui.git --branch main sui
-          echo "$(cargo bin)/sui" >> $GITHUB_PATH
+          if ! command -v sui &> /dev/null; then
+            cargo install --locked --git https://github.com/MystenLabs/sui.git --branch main sui
+          fi
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install Dependencies
         run: yarn

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Install Anchor (Solana)
         uses: metadaoproject/setup-anchor@v3.1
 
+      - name: Install Sui CLI
+        run: |
+          cargo install --locked --git https://github.com/MystenLabs/sui.git --branch main sui
+          echo "$(cargo bin)/sui" >> $GITHUB_PATH
+
       - name: Install Dependencies
         run: yarn
 

--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ Make sure you have the following installed to use Localnet:
 
 ## Documentation
 
-Learn more about Localnet:  
+Learn about Localnet:  
 https://www.zetachain.com/docs/developers/tutorials/localnet/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "del-cli dist && tsc && cpx 'packages/localnet/src/solana/**/*' dist/localnet/src/solana/ && cpx 'packages/localnet/src/sui/**/*' dist/localnet/src/sui/",
     "lint:fix": "eslint --ext .js,.ts . --fix",
-    "lint": "eslint --ext .js,.ts ."
+    "lint": "eslint --ext .js,.ts .",
+    "localnet": "yarn build && npx hardhat localnet"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
       "require": "./dist/localnet/src/index.js",
       "types": "./dist/localnet/src/index.d.ts"
     },
+    "./solana/idl/gateway.json": "./dist/localnet/src/solana/idl/gateway.json",
     "./solana/deploy/gateway.so": "./dist/localnet/src/solana/deploy/gateway.so",
     "./solana/deploy/gateway-keypair.json": "./dist/localnet/src/solana/deploy/gateway-keypair.json",
     "./sui/gateway.mv": "./dist/localnet/src/sui/gateway.mv",

--- a/packages/localnet/src/evmExecute.ts
+++ b/packages/localnet/src/evmExecute.ts
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { BigNumberish, ethers } from "ethers";
 
 import { deployOpts } from "./deployOpts";
 import { log } from "./log";
@@ -13,6 +13,7 @@ export const evmExecute = async ({
   receiver,
   message,
   callOptions,
+  amount,
 }: {
   callOptions: any;
   evmContracts: any;
@@ -23,6 +24,7 @@ export const evmExecute = async ({
   sender: any;
   tss: any;
   zrc20: any;
+  amount: BigNumberish;
 }) => {
   const chainID = foreignCoins.find(
     (coin: any) => coin.zrc20_contract_address === zrc20
@@ -46,7 +48,10 @@ export const evmExecute = async ({
   }
   const executeTx = await evmContracts[chainID].gatewayEVM
     .connect(tss)
-    .execute(messageContext, receiver, message, deployOpts);
+    .execute(messageContext, receiver, message, {
+      value: amount,
+      ...deployOpts,
+    });
 
   const logs = await provider.getLogs({
     address: receiver,

--- a/packages/localnet/src/evmExecute.ts
+++ b/packages/localnet/src/evmExecute.ts
@@ -15,6 +15,7 @@ export const evmExecute = async ({
   callOptions,
   amount,
 }: {
+  amount: BigNumberish;
   callOptions: any;
   evmContracts: any;
   foreignCoins: any[];
@@ -24,7 +25,6 @@ export const evmExecute = async ({
   sender: any;
   tss: any;
   zrc20: any;
-  amount: BigNumberish;
 }) => {
   const chainID = foreignCoins.find(
     (coin: any) => coin.zrc20_contract_address === zrc20

--- a/packages/localnet/src/solanaSetup.ts
+++ b/packages/localnet/src/solanaSetup.ts
@@ -1,16 +1,17 @@
 import * as anchor from "@coral-xyz/anchor";
+import { Keypair } from "@solana/web3.js";
+import * as bip39 from "bip39";
 import { exec } from "child_process";
 import { ec as EC } from "elliptic";
 import { keccak256 } from "ethereumjs-util";
 import { ethers } from "ethers";
 import * as fs from "fs";
+import * as os from "os";
 import path from "path";
 import util from "util";
-import * as bip39 from "bip39";
-import { Keypair } from "@solana/web3.js";
-import { MNEMONIC } from "./suiSetup";
+
 import Gateway_IDL from "./solana/idl/gateway.json";
-import * as os from "os";
+import { MNEMONIC } from "./suiSetup";
 
 const execAsync = util.promisify(exec);
 

--- a/packages/localnet/src/suiSetup.ts
+++ b/packages/localnet/src/suiSetup.ts
@@ -10,7 +10,8 @@ const GAS_BUDGET = 5_000_000_000;
 const NODE_RPC = "http://127.0.0.1:9000";
 const FAUCET_URL = "http://127.0.0.1:9123";
 const DERIVATION_PATH = "m/44'/784'/0'/0'/0'";
-const MNEMONIC =
+
+export const MNEMONIC =
   "grape subway rack mean march bubble carry avoid muffin consider thing street";
 
 const generateAccount = (mnemonic: string) => {

--- a/packages/localnet/src/zetachainCall.ts
+++ b/packages/localnet/src/zetachainCall.ts
@@ -41,6 +41,7 @@ export const zetachainCall = async ({
       sender,
       tss,
       zrc20,
+      amount: 0,
     });
   } catch (err: any) {
     if (exitOnError) {

--- a/packages/localnet/src/zetachainCall.ts
+++ b/packages/localnet/src/zetachainCall.ts
@@ -32,6 +32,7 @@ export const zetachainCall = async ({
 
   try {
     await evmExecute({
+      amount: 0,
       callOptions,
       evmContracts,
       foreignCoins,
@@ -41,7 +42,6 @@ export const zetachainCall = async ({
       sender,
       tss,
       zrc20,
-      amount: 0,
     });
   } catch (err: any) {
     if (exitOnError) {

--- a/packages/localnet/src/zetachainWithdraw.ts
+++ b/packages/localnet/src/zetachainWithdraw.ts
@@ -31,7 +31,6 @@ export const zetachainWithdraw = async ({
 }) => {
   log("7001", "Gateway: 'Withdrawn' event emitted");
   const [sender, , receiver, zrc20, amount, , , , , revertOptions] = args;
-  console.log("!!!", args);
   const chainID = foreignCoins.find(
     (coin: any) => coin.zrc20_contract_address === zrc20
   )?.foreign_chain_id;

--- a/packages/localnet/src/zetachainWithdraw.ts
+++ b/packages/localnet/src/zetachainWithdraw.ts
@@ -31,6 +31,7 @@ export const zetachainWithdraw = async ({
 }) => {
   log("7001", "Gateway: 'Withdrawn' event emitted");
   const [sender, , receiver, zrc20, amount, , , , , revertOptions] = args;
+  console.log("!!!", args);
   const chainID = foreignCoins.find(
     (coin: any) => coin.zrc20_contract_address === zrc20
   )?.foreign_chain_id;

--- a/packages/localnet/src/zetachainWithdrawAndCall.ts
+++ b/packages/localnet/src/zetachainWithdrawAndCall.ts
@@ -62,7 +62,6 @@ export const zetachainWithdrawAndCall = async ({
         );
       }
     }
-
     if (isGasToken) {
       await evmExecute({
         callOptions,
@@ -74,6 +73,7 @@ export const zetachainWithdrawAndCall = async ({
         sender,
         tss,
         zrc20,
+        amount,
       });
     } else {
       await evmCustodyWithdrawAndCall({

--- a/packages/localnet/src/zetachainWithdrawAndCall.ts
+++ b/packages/localnet/src/zetachainWithdrawAndCall.ts
@@ -64,6 +64,7 @@ export const zetachainWithdrawAndCall = async ({
     }
     if (isGasToken) {
       await evmExecute({
+        amount,
         callOptions,
         evmContracts,
         foreignCoins,
@@ -73,7 +74,6 @@ export const zetachainWithdrawAndCall = async ({
         sender,
         tss,
         zrc20,
-        amount,
       });
     } else {
       await evmCustodyWithdrawAndCall({

--- a/packages/tasks/src/solanaDeposit.ts
+++ b/packages/tasks/src/solanaDeposit.ts
@@ -1,11 +1,16 @@
 import * as anchor from "@coral-xyz/anchor";
 import { ethers } from "ethers";
 import { task } from "hardhat/config";
+import * as fs from "fs";
 
-import Gateway_IDL from "../../localnet/src/solana/idl/gateway.json";
 import { getKeypair } from "./solanaDepositAndCall";
 
 const solanaDeposit = async (args: any) => {
+  const gatewayPath = require.resolve(
+    "@zetachain/localnet/solana/idl/gateway.json"
+  );
+  const Gateway_IDL = JSON.parse(fs.readFileSync(gatewayPath, "utf-8"));
+
   const keypair = await getKeypair(args.mnemonic);
 
   const provider = new anchor.AnchorProvider(

--- a/packages/tasks/src/solanaDeposit.ts
+++ b/packages/tasks/src/solanaDeposit.ts
@@ -1,7 +1,7 @@
 import * as anchor from "@coral-xyz/anchor";
 import { ethers } from "ethers";
-import { task } from "hardhat/config";
 import * as fs from "fs";
+import { task } from "hardhat/config";
 
 import { getKeypair } from "./solanaDepositAndCall";
 

--- a/packages/tasks/src/solanaDeposit.ts
+++ b/packages/tasks/src/solanaDeposit.ts
@@ -3,9 +3,21 @@ import { ethers } from "ethers";
 import { task } from "hardhat/config";
 
 import Gateway_IDL from "../../localnet/src/solana/idl/gateway.json";
+import { getKeypair } from "./solanaDepositAndCall";
 
 const solanaDeposit = async (args: any) => {
-  const gatewayProgram = new anchor.Program(Gateway_IDL as anchor.Idl);
+  const keypair = await getKeypair(args.mnemonic);
+
+  const provider = new anchor.AnchorProvider(
+    new anchor.web3.Connection("http://localhost:8899"),
+    new anchor.Wallet(keypair),
+    {}
+  );
+
+  const gatewayProgram = new anchor.Program(
+    Gateway_IDL as anchor.Idl,
+    provider
+  );
 
   await gatewayProgram.methods
     .deposit(
@@ -18,8 +30,9 @@ const solanaDeposit = async (args: any) => {
 
 export const solanaDepositTask = task(
   "localnet:solana-deposit",
-  "Solana deposit and call",
+  "Solana deposit",
   solanaDeposit
 )
-  .addParam("receiver", "Address to deposit and call")
-  .addParam("amount", "Amount to deposit and call");
+  .addParam("receiver", "Address to deposit to")
+  .addParam("amount", "Amount to deposit")
+  .addOptionalParam("mnemonic", "Mnemonic for generating a keypair");

--- a/packages/tasks/src/solanaDepositAndCall.ts
+++ b/packages/tasks/src/solanaDepositAndCall.ts
@@ -5,7 +5,6 @@ import * as fs from "fs";
 import { task } from "hardhat/config";
 import * as path from "path";
 
-import Gateway_IDL from "../../localnet/src/solana/idl/gateway.json";
 import { keypairFromMnemonic } from "../../localnet/src/solanaSetup";
 
 export const getDefaultKeypair = (): Keypair | null => {
@@ -39,6 +38,11 @@ export const getKeypair = async (mnemonic?: string): Promise<Keypair> => {
 };
 
 const solanaDepositAndCall = async (args: any) => {
+  const gatewayPath = require.resolve(
+    "@zetachain/localnet/solana/idl/gateway.json"
+  );
+  const Gateway_IDL = JSON.parse(fs.readFileSync(gatewayPath, "utf-8"));
+
   const valuesArray = args.values.map((value: any, index: any) => {
     const type = JSON.parse(args.types)[index];
 

--- a/packages/tasks/src/solanaDepositAndCall.ts
+++ b/packages/tasks/src/solanaDepositAndCall.ts
@@ -1,8 +1,8 @@
 import * as anchor from "@coral-xyz/anchor";
-import { AbiCoder, ethers } from "ethers";
-import { task } from "hardhat/config";
 import { Keypair } from "@solana/web3.js";
+import { AbiCoder, ethers } from "ethers";
 import * as fs from "fs";
+import { task } from "hardhat/config";
 import * as path from "path";
 
 import Gateway_IDL from "../../localnet/src/solana/idl/gateway.json";


### PR DESCRIPTION
- Fixed a bug when withdrawing and calling, `evmExecute` was called without gas tokens, so this broke for example universal NFT/FT, when EVM `onCall` expected to get tokens: https://github.com/zeta-chain/standard-contracts/blob/32d34c73083882e32389679e0f2228fe2facd4a3/contracts/token/contracts/evm/UniversalTokenCore.sol#L166-L170
- Add `mnemonic` optional arg to Solana tasks
- Added Solana to CI
- Solana setup:
  - generate a key in `~/.config/solana/id.json` if it doesn't exist (otherwise `solana program deploy` complains)
  - Airdrop to the default user.
- added `yarn localnet` command to build and run localnet
- Solana deposit/deposit and call import IDL correctly from this npm package

Both Sui and Solana right now are using the same mnemonic for a default user. In both networks, default user gets tokens from the faucet. We'll need to refactor this to allow proper config for default users.

Using this version in https://github.com/zeta-chain/example-contracts/pull/232