### PR TITLE
fix: use `CallOptions.gasLimit` for outgoing calls

### DIFF
--- a/packages/localnet/src/constants.ts
+++ b/packages/localnet/src/constants.ts
@@ -12,5 +12,5 @@ export const NetworkID = {
   Ethereum: "5",
   Solana: "901",
   Sui: "103",
-  ZetaChain: "7000",
+  ZetaChain: "7001",
 };

--- a/packages/localnet/src/evmCall.ts
+++ b/packages/localnet/src/evmCall.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 
+import { NetworkID } from "./constants";
 import { log, logErr } from "./log";
 import { zetachainExecute } from "./zetachainExecute";
 import { zetachainOnAbort } from "./zetachainOnAbort";
@@ -29,7 +30,7 @@ export const evmCall = async ({
     if (exitOnError) {
       throw new Error(err);
     }
-    logErr("7001", `Error executing onCall: ${err}`);
+    logErr(NetworkID.ZetaChain, `Error executing onCall: ${err}`);
     // No asset calls don't support reverts, so aborting
     const revertOptions = args[5];
     const abortAddress = revertOptions[2];

--- a/packages/localnet/src/evmCustodyWithdrawAndCall.ts
+++ b/packages/localnet/src/evmCustodyWithdrawAndCall.ts
@@ -30,14 +30,9 @@ export const evmCustodyWithdrawAndCall = async ({
 
     const executeTx = await evmContracts.custody
       .connect(tss)
-      .withdrawAndCall(
-        messageContext,
-        receiver,
-        asset,
-        amount,
-        message,
-        deployOpts
-      );
+      .withdrawAndCall(messageContext, receiver, asset, amount, message, {
+        gasLimit: callOptions.gasLimit,
+      });
     await executeTx.wait();
   } catch (error: any) {
     throw new Error(

--- a/packages/localnet/src/evmCustodyWithdrawAndCall.ts
+++ b/packages/localnet/src/evmCustodyWithdrawAndCall.ts
@@ -1,7 +1,5 @@
 import { ethers } from "ethers";
 
-import { deployOpts } from "./deployOpts";
-
 export const evmCustodyWithdrawAndCall = async ({
   evmContracts,
   tss,

--- a/packages/localnet/src/evmDeposit.ts
+++ b/packages/localnet/src/evmDeposit.ts
@@ -2,6 +2,7 @@ import * as UniswapV2Router02 from "@uniswap/v2-periphery/build/UniswapV2Router0
 import * as ZRC20 from "@zetachain/protocol-contracts/abi/ZRC20.sol/ZRC20.json";
 import { ethers } from "ethers";
 
+import { NetworkID } from "./constants";
 import { evmOnRevert } from "./evmOnRevert";
 import { log, logErr } from "./log";
 import { zetachainDeposit } from "./zetachainDeposit";
@@ -29,7 +30,7 @@ export const evmDeposit = async ({
   }
 
   if (!foreignCoin) {
-    logErr("7001", `Foreign coin not found for asset: ${asset}`);
+    logErr(NetworkID.ZetaChain, `Foreign coin not found for asset: ${asset}`);
     return;
   }
 
@@ -45,7 +46,7 @@ export const evmDeposit = async ({
     if (exitOnError) {
       throw new Error(err);
     }
-    logErr("7001", `Error depositing: ${err}`);
+    logErr(NetworkID.ZetaChain, `Error depositing: ${err}`);
     const zrc20Contract = new ethers.Contract(zrc20, ZRC20.abi, deployer);
     const [gasZRC20, gasFee] = await zrc20Contract.withdrawGasFeeWithGasLimit(
       revertOptions[4]
@@ -181,7 +182,10 @@ const swapToCoverGas = async (
 
     await swapTx.wait();
   } catch (swapError) {
-    logErr("7001", `Error performing swap on Uniswap: ${swapError}`);
+    logErr(
+      NetworkID.ZetaChain,
+      `Error performing swap on Uniswap: ${swapError}`
+    );
   }
 
   const amountInZeta = await getAmounts(

--- a/packages/localnet/src/evmDepositAndCall.ts
+++ b/packages/localnet/src/evmDepositAndCall.ts
@@ -15,6 +15,7 @@ export const evmDepositAndCall = async ({
   provider,
   zetachainContracts,
   gatewayEVM,
+  tss,
 }: any) => {
   log(chainID, "Gateway: DepositedAndCalled event emitted");
   const [sender, , amount, asset, , revertOptions] = args;
@@ -73,6 +74,8 @@ export const evmDepositAndCall = async ({
         revertOptions,
         sender,
         token,
+        provider,
+        tss,
       });
     } else {
       log(

--- a/packages/localnet/src/evmDepositAndCall.ts
+++ b/packages/localnet/src/evmDepositAndCall.ts
@@ -71,10 +71,10 @@ export const evmDepositAndCall = async ({
         err,
         gatewayEVM,
         isGas,
+        provider,
         revertOptions,
         sender,
         token,
-        provider,
         tss,
       });
     } else {

--- a/packages/localnet/src/evmDepositAndCall.ts
+++ b/packages/localnet/src/evmDepositAndCall.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 
+import { NetworkID } from "./constants";
 import { evmOnRevert } from "./evmOnRevert";
 import { log, logErr } from "./log";
 import { zetachainDepositAndCall } from "./zetachainDepositAndCall";
@@ -31,7 +32,7 @@ export const evmDepositAndCall = async ({
   }
 
   if (!foreignCoin) {
-    logErr("7001", `Foreign coin not found for asset: ${asset}`);
+    logErr(NetworkID.ZetaChain, `Foreign coin not found for asset: ${asset}`);
     return;
   }
 
@@ -47,7 +48,7 @@ export const evmDepositAndCall = async ({
     if (exitOnError) {
       throw new Error(err);
     }
-    logErr("7001", `onCall failed: ${err}`);
+    logErr(NetworkID.ZetaChain, `onCall failed: ${err}`);
     const gasLimit = revertOptions[4];
     // TODO: instead of swapping, get a quote from Uniswap to estimate if the amount is sufficient. Do the same for evmDeposit
     const { revertGasFee, isGas, token, zrc20 } = await zetachainSwapToCoverGas(
@@ -79,7 +80,7 @@ export const evmDepositAndCall = async ({
       });
     } else {
       log(
-        "7001",
+        NetworkID.ZetaChain,
         `Cannot initiate a revert, deposited amount ${amount} is less than gas fee ${revertGasFee}`
       );
       const abortAddress = revertOptions[2];

--- a/packages/localnet/src/evmExecute.ts
+++ b/packages/localnet/src/evmExecute.ts
@@ -1,7 +1,6 @@
 import { BigNumberish, ethers, GasCostPlugin } from "ethers";
 
 import { NetworkID } from "./constants";
-import { deployOpts } from "./deployOpts";
 import { log } from "./log";
 
 export const evmExecute = async ({

--- a/packages/localnet/src/evmExecute.ts
+++ b/packages/localnet/src/evmExecute.ts
@@ -1,4 +1,4 @@
-import { BigNumberish, ethers } from "ethers";
+import { BigNumberish, ethers, GasCostPlugin } from "ethers";
 
 import { NetworkID } from "./constants";
 import { deployOpts } from "./deployOpts";
@@ -49,7 +49,7 @@ export const evmExecute = async ({
     .connect(contracts.tss)
     .execute(messageContext, receiver, message, {
       value: amount,
-      ...deployOpts,
+      gasLimit: callOptions.gasLimit,
     });
 
   const logs = await contracts.provider.getLogs({

--- a/packages/localnet/src/evmExecute.ts
+++ b/packages/localnet/src/evmExecute.ts
@@ -48,8 +48,8 @@ export const evmExecute = async ({
   const executeTx = await evmContracts.gatewayEVM
     .connect(contracts.tss)
     .execute(messageContext, receiver, message, {
-      value: amount,
       gasLimit: callOptions.gasLimit,
+      value: amount,
     });
 
   const logs = await contracts.provider.getLogs({

--- a/packages/localnet/src/evmOnRevert.ts
+++ b/packages/localnet/src/evmOnRevert.ts
@@ -1,7 +1,5 @@
 import * as ZRC20 from "@zetachain/protocol-contracts/abi/ZRC20.sol/ZRC20.json";
 import { ethers, NonceManager } from "ethers";
-
-import { deployOpts } from "./deployOpts";
 import { log, logErr } from "./log";
 
 export const evmOnRevert = async ({

--- a/packages/localnet/src/evmOnRevert.ts
+++ b/packages/localnet/src/evmOnRevert.ts
@@ -34,8 +34,8 @@ export const evmOnRevert = async ({
         tx = await gatewayEVM
           .connect(tss)
           .executeRevert(revertAddress, "0x", revertContext, {
-            value: amount,
             gasLimit: onRevertGasLimit,
+            value: amount,
           });
       } else {
         tx = await custody

--- a/packages/localnet/src/evmOnRevert.ts
+++ b/packages/localnet/src/evmOnRevert.ts
@@ -17,7 +17,8 @@ export const evmOnRevert = async ({
   tss,
   gatewayEVM,
 }: any) => {
-  const [revertAddress, callOnRevert, , revertMessage] = revertOptions;
+  const [revertAddress, callOnRevert, , revertMessage, onRevertGasLimit] =
+    revertOptions;
   const revertContext = { amount, asset, revertMessage, sender };
   if (callOnRevert) {
     try {
@@ -33,8 +34,8 @@ export const evmOnRevert = async ({
         tx = await gatewayEVM
           .connect(tss)
           .executeRevert(revertAddress, "0x", revertContext, {
-            deployOpts,
             value: amount,
+            gasLimit: onRevertGasLimit,
           });
       } else {
         tx = await custody
@@ -45,7 +46,7 @@ export const evmOnRevert = async ({
             amount,
             "0x",
             revertContext,
-            deployOpts
+            { gasLimit: onRevertGasLimit }
           );
       }
       await tx.wait();

--- a/packages/localnet/src/evmOnRevert.ts
+++ b/packages/localnet/src/evmOnRevert.ts
@@ -1,5 +1,6 @@
 import * as ZRC20 from "@zetachain/protocol-contracts/abi/ZRC20.sol/ZRC20.json";
 import { ethers, NonceManager } from "ethers";
+
 import { log, logErr } from "./log";
 
 export const evmOnRevert = async ({

--- a/packages/localnet/src/evmSetup.ts
+++ b/packages/localnet/src/evmSetup.ts
@@ -3,7 +3,7 @@ import * as ERC1967Proxy from "@zetachain/protocol-contracts/abi/ERC1967Proxy.so
 import * as GatewayEVM from "@zetachain/protocol-contracts/abi/GatewayEVM.sol/GatewayEVM.json";
 import * as TestERC20 from "@zetachain/protocol-contracts/abi/TestERC20.sol/TestERC20.json";
 import * as ZetaConnectorNonNative from "@zetachain/protocol-contracts/abi/ZetaConnectorNonNative.sol/ZetaConnectorNonNative.json";
-import { ethers, Signer } from "ethers";
+import { ethers } from "ethers";
 
 import { deployOpts } from "./deployOpts";
 import { evmCall } from "./evmCall";

--- a/packages/localnet/src/evmSetup.ts
+++ b/packages/localnet/src/evmSetup.ts
@@ -155,6 +155,7 @@ export const evmSetup = async ({
       gatewayEVM,
       provider,
       zetachainContracts,
+      tss,
     });
   });
 

--- a/packages/localnet/src/evmSetup.ts
+++ b/packages/localnet/src/evmSetup.ts
@@ -154,8 +154,8 @@ export const evmSetup = async ({
       foreignCoins,
       gatewayEVM,
       provider,
-      zetachainContracts,
       tss,
+      zetachainContracts,
     });
   });
 

--- a/packages/localnet/src/solanaDeposit.ts
+++ b/packages/localnet/src/solanaDeposit.ts
@@ -28,7 +28,7 @@ export const solanaDeposit = async ({
     }
 
     if (!foreignCoin) {
-      logErr("7001", `Foreign coin not found for asset: ${asset}`);
+      logErr(NetworkID.ZetaChain, `Foreign coin not found for asset: ${asset}`);
       return;
     }
 
@@ -39,7 +39,7 @@ export const solanaDeposit = async ({
       zetachainContracts,
     });
   } catch (err) {
-    logErr("7001", `Error depositing: ${err}`);
+    logErr(NetworkID.ZetaChain, `Error depositing: ${err}`);
     const { revertGasFee } = await zetachainSwapToCoverGas({
       amount,
       asset,

--- a/packages/localnet/src/solanaDepositAndCall.ts
+++ b/packages/localnet/src/solanaDepositAndCall.ts
@@ -28,7 +28,7 @@ export const solanaDepositAndCall = async ({
     }
 
     if (!foreignCoin) {
-      logErr("7001", `Foreign coin not found for asset: ${asset}`);
+      logErr(NetworkID.ZetaChain, `Foreign coin not found for asset: ${asset}`);
       return;
     }
     await zetachainDepositAndCall({

--- a/packages/localnet/src/suiSetup.ts
+++ b/packages/localnet/src/suiSetup.ts
@@ -65,11 +65,6 @@ export const suiSetup = async ({
 
   publishTx.transferObjects([upgradeCap], publisherAddress);
 
-  let moduleId: string | null = null;
-  let gatewayObjectId: string | null = null;
-  let adminCapObjectId: string | null = null;
-  let withdrawCapObjectId: string | null = null;
-
   const publishResult = await client.signAndExecuteTransaction({
     options: {
       showEffects: true,
@@ -97,47 +92,10 @@ export const suiSetup = async ({
       change.type === "created" &&
       change.objectType.includes("gateway::WithdrawCap")
   );
-  const adminCapObject = publishResult.objectChanges?.find(
-    (change) =>
-      change.type === "created" &&
-      change.objectType.includes("gateway::AdminCap")
-  );
 
-  if (publishedModule) {
-    moduleId = (publishedModule as any).packageId;
-    console.log("Published Module ID:", moduleId);
-  } else {
-    throw new Error("Failed to get module ID");
-  }
-
-  if (gatewayObject) {
-    gatewayObjectId = (gatewayObject as any).objectId;
-    console.log("Gateway Object ID:", gatewayObjectId);
-  } else {
-    console.warn("No Gateway object found after publish.");
-  }
-
-  if (withdrawCapObject) {
-    withdrawCapObjectId = (withdrawCapObject as any).objectId;
-    console.log("Withdraw Cap Object ID:", withdrawCapObjectId);
-  } else {
-    console.warn("No WithdrawCap object found after publish.");
-  }
-
-  if (adminCapObject) {
-    adminCapObjectId = (adminCapObject as any).objectId;
-    console.log("AdminCap Object ID:", adminCapObjectId);
-  } else {
-    console.warn("No AdminCap object found after publish.");
-  }
-
-  if (!moduleId) {
-    throw new Error("Failed to get module ID");
-  }
-
-  if (!gatewayObjectId) {
-    throw new Error("Failed to get gateway object ID");
-  }
+  const moduleId = (publishedModule as any).packageId;
+  const gatewayObjectId = (gatewayObject as any).objectId;
+  const withdrawCapObjectId = (withdrawCapObject as any).objectId;
 
   pollEvents({
     client,

--- a/packages/localnet/src/zetachainCall.ts
+++ b/packages/localnet/src/zetachainCall.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 
+import { NetworkID } from "./constants";
 import { deployOpts } from "./deployOpts";
 import { evmExecute } from "./evmExecute";
 import { log, logErr } from "./log";
@@ -18,7 +19,7 @@ export const zetachainCall = async ({
     provider,
     zetachainContracts: { fungibleModuleSigner, gatewayZEVM },
   } = contracts;
-  log("7001", "Gateway: 'Called' event emitted");
+  log(NetworkID.ZetaChain, "Gateway: 'Called' event emitted");
   const [sender, zrc20, receiver, message, callOptions, revertOptions] = args;
   const chainID = contracts.foreignCoins.find(
     (coin: any) => coin.zrc20_contract_address === zrc20

--- a/packages/localnet/src/zetachainDeposit.ts
+++ b/packages/localnet/src/zetachainDeposit.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 
+import { NetworkID } from "./constants";
 import { deployOpts } from "./deployOpts";
 import { log, logErr } from "./log";
 
@@ -23,7 +24,7 @@ export const zetachainDeposit = async ({
   }
 
   if (!foreignCoin) {
-    logErr("7001", `Foreign coin not found for asset: ${asset}`);
+    logErr(NetworkID.ZetaChain, `Foreign coin not found for asset: ${asset}`);
     return;
   }
   const zrc20 = foreignCoin.zrc20_contract_address;
@@ -31,5 +32,8 @@ export const zetachainDeposit = async ({
     .connect(zetachainContracts.fungibleModuleSigner)
     .deposit(zrc20, amount, receiver, deployOpts);
   await tx.wait();
-  log("7001", `Deposited ${amount} of ${zrc20} tokens to ${receiver}`);
+  log(
+    NetworkID.ZetaChain,
+    `Deposited ${amount} of ${zrc20} tokens to ${receiver}`
+  );
 };

--- a/packages/localnet/src/zetachainDepositAndCall.ts
+++ b/packages/localnet/src/zetachainDepositAndCall.ts
@@ -1,7 +1,6 @@
 import { ethers } from "ethers";
 
 import { NetworkID } from "./constants";
-import { deployOpts } from "./deployOpts";
 import { log, logErr } from "./log";
 
 export const zetachainDepositAndCall = async ({
@@ -23,7 +22,7 @@ export const zetachainDepositAndCall = async ({
   }
 
   if (!foreignCoin) {
-    logErr("7001", `Foreign coin not found for asset: ${asset}`);
+    logErr(NetworkID.ZetaChain, `Foreign coin not found for asset: ${asset}`);
     return;
   }
   const zrc20 = foreignCoin.zrc20_contract_address;
@@ -38,7 +37,7 @@ export const zetachainDepositAndCall = async ({
       : sender,
   };
   log(
-    "7001",
+    NetworkID.ZetaChain,
     `Universal contract ${receiver} executing onCall (context: ${JSON.stringify(
       context
     )}), zrc20: ${zrc20}, amount: ${amount}, message: ${message})`
@@ -54,6 +53,6 @@ export const zetachainDepositAndCall = async ({
     fromBlock: "latest",
   });
   logs.forEach((data: any) => {
-    log("7001", `Event from onCall: ${JSON.stringify(data)}`);
+    log(NetworkID.ZetaChain, `Event from onCall: ${JSON.stringify(data)}`);
   });
 };

--- a/packages/localnet/src/zetachainDepositAndCall.ts
+++ b/packages/localnet/src/zetachainDepositAndCall.ts
@@ -45,7 +45,9 @@ export const zetachainDepositAndCall = async ({
   );
   const tx = await zetachainContracts.gatewayZEVM
     .connect(zetachainContracts.fungibleModuleSigner)
-    .depositAndCall(context, zrc20, amount, receiver, message, deployOpts);
+    .depositAndCall(context, zrc20, amount, receiver, message, {
+      gasLimit: 1_500_000,
+    });
   await tx.wait();
   const logs = await provider.getLogs({
     address: receiver,

--- a/packages/localnet/src/zetachainExecute.ts
+++ b/packages/localnet/src/zetachainExecute.ts
@@ -35,7 +35,9 @@ export const zetachainExecute = async ({
     );
     const executeTx = await zetachainContracts.gatewayZEVM
       .connect(zetachainContracts.fungibleModuleSigner)
-      .execute(context, zrc20, 0, receiver, message, deployOpts);
+      .execute(context, zrc20, 0, receiver, message, {
+        gasLimit: 1_500_000,
+      });
     await executeTx.wait();
     const logs = await provider.getLogs({
       address: receiver,

--- a/packages/localnet/src/zetachainExecute.ts
+++ b/packages/localnet/src/zetachainExecute.ts
@@ -1,6 +1,6 @@
 import { ethers, NonceManager } from "ethers";
 
-import { deployOpts } from "./deployOpts";
+import { NetworkID } from "./constants";
 import { log, logErr } from "./log";
 import { zetachainOnAbort } from "./zetachainOnAbort";
 
@@ -28,7 +28,7 @@ export const zetachainExecute = async ({
     )?.zrc20_contract_address;
 
     log(
-      "7001",
+      NetworkID.ZetaChain,
       `Universal contract ${receiver} executing onCall (context: ${JSON.stringify(
         context
       )}), zrc20: ${zrc20}, amount: 0, message: ${message})`
@@ -45,13 +45,13 @@ export const zetachainExecute = async ({
     });
 
     logs.forEach((data: any) => {
-      log("7001", `Event from onCall: ${JSON.stringify(data)}`);
+      log(NetworkID.ZetaChain, `Event from onCall: ${JSON.stringify(data)}`);
     });
   } catch (err: any) {
     if (exitOnError) {
       throw new Error(err);
     }
-    logErr("7001", `Error executing onCall: ${err}`);
+    logErr(NetworkID.ZetaChain, `Error executing onCall: ${err}`);
     // No asset calls don't support reverts, so aborting
     return await zetachainOnAbort({
       abortAddress: abortAddress,

--- a/packages/localnet/src/zetachainOnAbort.ts
+++ b/packages/localnet/src/zetachainOnAbort.ts
@@ -64,7 +64,9 @@ export const zetachainOnAbort = async ({
             context
           )}`
         );
-        const abortTx = await abortableContract.onAbort(context);
+        const abortTx = await abortableContract.onAbort(context, {
+          gasLimit: 1_500_000,
+        });
         await abortTx.wait();
         const logs = await provider.getLogs({
           address: abortAddress,

--- a/packages/localnet/src/zetachainOnAbort.ts
+++ b/packages/localnet/src/zetachainOnAbort.ts
@@ -1,6 +1,7 @@
 import * as ZRC20 from "@zetachain/protocol-contracts/abi/ZRC20.sol/ZRC20.json";
 import { ethers } from "ethers";
 
+import { NetworkID } from "./constants";
 import { log, logErr } from "./log";
 
 export const zetachainOnAbort = async ({
@@ -22,10 +23,10 @@ export const zetachainOnAbort = async ({
 
   try {
     if (abortAddress === ethers.ZeroAddress) {
-      logErr("7001", `abortAddress is zero`);
+      logErr(NetworkID.ZetaChain, `abortAddress is zero`);
       if (asset !== ethers.ZeroAddress && amount > 0) {
         logErr(
-          "7001",
+          NetworkID.ZetaChain,
           `Transferring ${amount} of ${asset} tokens to sender ${sender}`
         );
 
@@ -35,7 +36,10 @@ export const zetachainOnAbort = async ({
         throw new Error(`Can't transfer ${amount} of ${asset} tokens`);
       }
     } else {
-      log("7001", `Transferring tokens to abortAddress ${abortAddress}`);
+      log(
+        NetworkID.ZetaChain,
+        `Transferring tokens to abortAddress ${abortAddress}`
+      );
       if (asset !== ethers.ZeroAddress && amount > 0) {
         const transferTx = await assetContract.transfer(abortAddress, amount);
         await transferTx.wait();
@@ -59,7 +63,7 @@ export const zetachainOnAbort = async ({
         );
 
         log(
-          "7001",
+          NetworkID.ZetaChain,
           `Contract ${abortAddress} executing onAbort, context: ${JSON.stringify(
             context
           )}`
@@ -73,14 +77,17 @@ export const zetachainOnAbort = async ({
           fromBlock: "latest",
         });
         logs.forEach((data: any) => {
-          log("7001", `Event from onAbort: ${JSON.stringify(data)}`);
+          log(
+            NetworkID.ZetaChain,
+            `Event from onAbort: ${JSON.stringify(data)}`
+          );
         });
       } catch (err) {
         const error = `onAbort failed: ${err}`;
-        logErr("7001", error);
+        logErr(NetworkID.ZetaChain, error);
       }
     }
   } catch (err) {
-    logErr("7001", `Abort processing failed: ${err}`);
+    logErr(NetworkID.ZetaChain, `Abort processing failed: ${err}`);
   }
 };

--- a/packages/localnet/src/zetachainOnRevert.ts
+++ b/packages/localnet/src/zetachainOnRevert.ts
@@ -1,6 +1,7 @@
 import * as ZRC20 from "@zetachain/protocol-contracts/abi/ZRC20.sol/ZRC20.json";
-import { ethers, NonceManager } from "ethers";
+import { ethers } from "ethers";
 
+import { NetworkID } from "./constants";
 import { log } from "./log";
 import { logErr } from "./log";
 import { zetachainOnAbort } from "./zetachainOnAbort";
@@ -31,13 +32,13 @@ export const zetachainOnRevert = async ({
   );
 
   if (callOnRevert) {
-    log("7001", `callOnRevert is true`);
+    log(NetworkID.ZetaChain, `callOnRevert is true`);
     try {
       if (revertAddress === ethers.ZeroAddress) {
         throw new Error("revertAddress is zero");
       } else {
         logErr(
-          "7001",
+          NetworkID.ZetaChain,
           `Executing onRevert on revertAddress ${revertAddress}, context: ${JSON.stringify(
             revertContext
           )}`
@@ -62,12 +63,15 @@ export const zetachainOnRevert = async ({
           fromBlock: "latest",
         });
         logs.forEach((data: any) => {
-          log("7001", `Event from onRevert: ${JSON.stringify(data)}`);
+          log(
+            NetworkID.ZetaChain,
+            `Event from onRevert: ${JSON.stringify(data)}`
+          );
         });
       }
     } catch (err) {
       const error = `onRevert failed: ${err}`;
-      logErr("7001", error);
+      logErr(NetworkID.ZetaChain, error);
       await zetachainOnAbort({
         abortAddress,
         amount,
@@ -80,18 +84,21 @@ export const zetachainOnRevert = async ({
       });
     }
   } else {
-    log("7001", `callOnRevert is false`);
+    log(NetworkID.ZetaChain, `callOnRevert is false`);
     try {
       if (revertAddress === ethers.ZeroAddress) {
         throw new Error("revertAddress is zero");
       } else {
-        log("7001", `Transferring tokens to revertAddress ${revertAddress}`);
+        log(
+          NetworkID.ZetaChain,
+          `Transferring tokens to revertAddress ${revertAddress}`
+        );
         const transferTx = await assetContract.transfer(revertAddress, amount);
         await transferTx.wait();
       }
     } catch (err) {
       logErr(
-        "7001",
+        NetworkID.ZetaChain,
         `Token transfer to revertAddress ${revertAddress} failed: ${err}`
       );
       await zetachainOnAbort({

--- a/packages/localnet/src/zetachainOnRevert.ts
+++ b/packages/localnet/src/zetachainOnRevert.ts
@@ -46,17 +46,15 @@ export const zetachainOnRevert = async ({
         if (asset === ethers.ZeroAddress) {
           tx = await gatewayZEVM
             .connect(fungibleModuleSigner)
-            .executeRevert(revertAddress, revertContext, deployOpts);
+            .executeRevert(revertAddress, revertContext, {
+              gasLimit: 1_500_000,
+            });
         } else {
           tx = await gatewayZEVM
             .connect(fungibleModuleSigner)
-            .depositAndRevert(
-              asset,
-              amount,
-              revertAddress,
-              revertContext,
-              deployOpts
-            );
+            .depositAndRevert(asset, amount, revertAddress, revertContext, {
+              gasLimit: 1_500_000,
+            });
         }
         await tx.wait();
         const logs = await provider.getLogs({

--- a/packages/localnet/src/zetachainSwapToCoverGas.ts
+++ b/packages/localnet/src/zetachainSwapToCoverGas.ts
@@ -2,6 +2,7 @@ import * as UniswapV2Router02 from "@uniswap/v2-periphery/build/UniswapV2Router0
 import * as ZRC20 from "@zetachain/protocol-contracts/abi/ZRC20.sol/ZRC20.json";
 import { ethers } from "ethers";
 
+import { NetworkID } from "./constants";
 import { logErr } from "./log";
 
 export const zetachainSwapToCoverGas = async ({
@@ -25,7 +26,7 @@ export const zetachainSwapToCoverGas = async ({
   }
 
   if (!foreignCoin) {
-    logErr("7001", `Foreign coin not found for asset: ${asset}`);
+    logErr(NetworkID.ZetaChain, `Foreign coin not found for asset: ${asset}`);
     return { isGas: false, revertGasFee: 0, token: null };
   }
 
@@ -133,7 +134,10 @@ export const swapToCoverGas = async (
 
     await swapTx.wait();
   } catch (swapError) {
-    logErr("7001", `Error performing swap on Uniswap: ${swapError}`);
+    logErr(
+      NetworkID.ZetaChain,
+      `Error performing swap on Uniswap: ${swapError}`
+    );
   }
 
   const amountInZeta = await getAmounts(

--- a/packages/localnet/src/zetachainWithdraw.ts
+++ b/packages/localnet/src/zetachainWithdraw.ts
@@ -22,7 +22,7 @@ export const zetachainWithdraw = async ({
     provider,
     zetachainContracts: { fungibleModuleSigner, gatewayZEVM },
   } = contracts;
-  log("7001", "Gateway: 'Withdrawn' event emitted");
+  log(NetworkID.ZetaChain, "Gateway: 'Withdrawn' event emitted");
   const [sender, , receiver, zrc20, amount, , , , , revertOptions] = args;
   const chainID = foreignCoins.find(
     (coin: any) => coin.zrc20_contract_address === zrc20

--- a/packages/localnet/src/zetachainWithdrawAndCall.ts
+++ b/packages/localnet/src/zetachainWithdrawAndCall.ts
@@ -21,7 +21,7 @@ export const zetachainWithdrawAndCall = async ({
     zetachainContracts: { fungibleModuleSigner, gatewayZEVM },
   } = contracts;
 
-  log("7001", "Gateway: 'WithdrawnAndCalled' event emitted");
+  log(NetworkID.ZetaChain, "Gateway: 'WithdrawnAndCalled' event emitted");
   const [
     sender,
     ,


### PR DESCRIPTION
* Set 1.5M gas limit for incoming calls (`call`/`depositAndCall`) and for `onRevert`/`onAbort`
* Use `CallOptions.gasLimit` for outgoing calls
* execute EVM onRevert with correct gas limit
* Replace hard-coded chain ID "7001" with `NetworkID.ZetaChain`