### PR TITLE
feat: `--skip` param to skip specific chains when launching localnet

### DIFF
--- a/packages/localnet/src/index.ts
+++ b/packages/localnet/src/index.ts
@@ -20,9 +20,11 @@ const foreignCoins: any[] = [];
 export const initLocalnet = async ({
   port,
   exitOnError,
+  skip,
 }: {
   exitOnError: boolean;
   port: number;
+  skip: string[];
 }) => {
   const provider = new ethers.JsonRpcProvider(`http://127.0.0.1:${port}`);
   provider.pollingInterval = 100;
@@ -50,12 +52,14 @@ export const initLocalnet = async ({
         foreignCoins,
         provider,
         zetachainContracts,
+        skip: skip.includes("solana"),
       }),
       suiSetup({
         deployer,
         foreignCoins,
         provider,
         zetachainContracts,
+        skip: skip.includes("sui"),
       }),
       evmSetup({
         chainID: NetworkID.Ethereum,
@@ -111,12 +115,7 @@ export const initLocalnet = async ({
     zetachainWithdrawAndCall({ args, contracts, exitOnError })
   );
 
-  const res = [
-    {
-      address: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-      chain: "solana",
-      type: "tokenProgram",
-    },
+  let res = [
     ...Object.entries(zetachainContracts)
       .filter(([, value]) => value.target !== undefined)
       .map(([key, value]) => {
@@ -183,8 +182,20 @@ export const initLocalnet = async ({
     }),
   ];
 
-  if (suiContracts) res.push(...suiContracts.addresses);
-  if (solanaContracts) res.push(...solanaContracts.addresses);
+  if (suiContracts) {
+    res = [...res, ...suiContracts.addresses];
+  }
+  if (solanaContracts) {
+    res = [
+      ...res,
+      ...solanaContracts.addresses,
+      {
+        address: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+        chain: "solana",
+        type: "tokenProgram",
+      },
+    ];
+  }
 
   return res;
 };

--- a/packages/localnet/src/index.ts
+++ b/packages/localnet/src/index.ts
@@ -51,15 +51,15 @@ export const initLocalnet = async ({
         deployer,
         foreignCoins,
         provider,
-        zetachainContracts,
         skip: skip.includes("solana"),
+        zetachainContracts,
       }),
       suiSetup({
         deployer,
         foreignCoins,
         provider,
-        zetachainContracts,
         skip: skip.includes("sui"),
+        zetachainContracts,
       }),
       evmSetup({
         chainID: NetworkID.Ethereum,

--- a/packages/localnet/src/solanaSetup.ts
+++ b/packages/localnet/src/solanaSetup.ts
@@ -101,8 +101,9 @@ export const solanaSetup = async ({
   foreignCoins,
   zetachainContracts,
   provider,
+  skip,
 }: any) => {
-  if (!(await isSolanaAvailable())) {
+  if (skip || !(await isSolanaAvailable())) {
     return;
   }
   const defaultLocalnetUserKeypair = await keypairFromMnemonic(MNEMONIC);

--- a/packages/localnet/src/suiSetup.ts
+++ b/packages/localnet/src/suiSetup.ts
@@ -44,8 +44,9 @@ export const suiSetup = async ({
   fungibleModuleSigner,
   zetachainContracts,
   provider,
+  skip,
 }: any) => {
-  if (!(await isSuiAvailable())) {
+  if (skip || !(await isSuiAvailable())) {
     return;
   }
 


### PR DESCRIPTION
* `--skip` flag to skip chain initialization even if the CLI for that chain is available. This can speed up init process if you only need specific chains, and will help you start localnet even if Sui/Solana setup you have is not compatible with localnet for some reason.
* fixed a bug where Solana token address still showed up in output even if Solana wasn't initialized

This should work:

```
npx hardhat localnet --skip solana

npx hardhat localnet --skip solana,sui
```