### PR TITLE
fix: throw an error when Solana init fails

### DIFF
--- a/packages/tasks/src/localnet.ts
+++ b/packages/tasks/src/localnet.ts
@@ -86,12 +86,17 @@ const localnet = async (args: any) => {
   if ((await isSolanaAvailable()) && !skip.includes("solana")) {
     solanaTestValidator = exec(`solana-test-validator --reset`);
 
+    // Record the output of the solana-test-validator.
+    // solanaError accumulates both errors and logs, but we only console log
+    // the value if the solana-test-validator exits with a non-zero code, so
+    // only errors are printed.
     if (solanaTestValidator.stdout) {
       solanaTestValidator.stdout.on("data", (data: string) => {
         solanaError += data;
       });
     }
 
+    // If the solana-test-validator exits with a non-zero code, print the error and exit.
     solanaTestValidator.on("exit", (code: number) => {
       if (code !== 0) {
         console.error(ansis.red(solanaError));

--- a/packages/tasks/src/localnet.ts
+++ b/packages/tasks/src/localnet.ts
@@ -82,26 +82,19 @@ const localnet = async (args: any) => {
   const skip = args.skip ? args.skip.split(",") : [];
 
   let solanaTestValidator: any;
+  let solanaError = "";
   if ((await isSolanaAvailable()) && !skip.includes("solana")) {
     solanaTestValidator = exec(`solana-test-validator --reset`);
 
-    // Add error handling for solana-test-validator
-    if (solanaTestValidator.stderr) {
-      solanaTestValidator.stderr.on("data", (data: string) => {
-        if (data.toLowerCase().includes("error")) {
-          console.error(ansis.red(`Solana test validator error: ${data}`));
-          cleanup();
-          process.exit(1);
-        }
+    if (solanaTestValidator.stdout) {
+      solanaTestValidator.stdout.on("data", (data: string) => {
+        solanaError += data;
       });
     }
 
-    // Add exit handler for the validator process
     solanaTestValidator.on("exit", (code: number) => {
       if (code !== 0) {
-        console.error(
-          ansis.red(`Solana test validator exited with code ${code}`)
-        );
+        console.error(ansis.red(solanaError));
         cleanup();
         process.exit(1);
       }


### PR DESCRIPTION
Right now if Solana is being initialized, and it fails, localnet will just silently not do anything and show standard Anvil output.

In this PR, we change this behavior, so that when Solana init fails, localnet exits with error code 1 and shows why Solana test validator failed to launch.

To test, switch to a version of Solana CLI not supported, for example, 1.18.15:

```
agave-install init 1.18.15
```

```
npx hardhat localnet
```

```
Ledger location: test-ledger
Log: test-ledger/validator.log
Initializing...
Error: failed to start validator: Failed to create ledger at test-ledger: io error: Error checking to unpack genesis archive: Archive error: extra entry found: "._genesis.bin" Regular
```

Switching to 2.0.0 fixes the issue:

```
agave-install init 2.0.0
```

```
npx hardhat localnet
```

We're outputting `stdout` and not `stderr`, because that's where the error is for some reason.