### PR TITLE
feat: Sui withdrawAndCall PoC

### DIFF
--- a/packages/localnet/src/suiSetup.ts
+++ b/packages/localnet/src/suiSetup.ts
@@ -308,8 +308,8 @@ const ensureDirectoryExists = () => {
     console.log(`✅ Directory is writable: ${LOCALNET_DIR}`);
   } catch (err) {
     console.log(
-      `🔒 Directory is not writable. Changing ownership to ${os.userInfo().username
-      }...`
+      `🔒 Directory is not writable. Changing ownership to 
+      ${os.userInfo().username}...`
     );
     runSudoCommand("chown", ["-R", os.userInfo().username, LOCALNET_DIR]);
 

--- a/packages/localnet/src/suiSetup.ts
+++ b/packages/localnet/src/suiSetup.ts
@@ -24,7 +24,7 @@ const PROTOCOL_CONTRACTS_REPO = path.join(
   LOCALNET_DIR,
   "protocol-contracts-sui"
 );
-const BRANCH_NAME = "main";
+const BRANCH_NAME = "withdraw-and-call-function";
 
 const generateAccount = (mnemonic: string) => {
   const seed = mnemonicToSeedSync(mnemonic);

--- a/packages/localnet/src/suiSetup.ts
+++ b/packages/localnet/src/suiSetup.ts
@@ -24,7 +24,7 @@ const PROTOCOL_CONTRACTS_REPO = path.join(
   LOCALNET_DIR,
   "protocol-contracts-sui"
 );
-const BRANCH_NAME = "withdraw-and-call-function";
+const BRANCH_NAME = "main";
 
 const generateAccount = (mnemonic: string) => {
   const seed = mnemonicToSeedSync(mnemonic);
@@ -308,8 +308,7 @@ const ensureDirectoryExists = () => {
     console.log(`✅ Directory is writable: ${LOCALNET_DIR}`);
   } catch (err) {
     console.log(
-      `🔒 Directory is not writable. Changing ownership to ${
-        os.userInfo().username
+      `🔒 Directory is not writable. Changing ownership to ${os.userInfo().username
       }...`
     );
     runSudoCommand("chown", ["-R", os.userInfo().username, LOCALNET_DIR]);

--- a/packages/localnet/src/suiWithdraw.ts
+++ b/packages/localnet/src/suiWithdraw.ts
@@ -33,22 +33,10 @@ export const suiWithdraw = async ({
   });
 
   try {
-    log(
-      NetworkID.Sui,
-      `Withdrawing ${amount} SUI tokens from the Gateway to ${sender}`
-    );
-
     const result = await client.signAndExecuteTransaction({
       signer: keypair,
       transaction: tx,
     });
-    log(
-      NetworkID.Sui,
-      `Withdrawing ${ethers.formatUnits(
-        amount,
-        9
-      )} SUI tokens from the Gateway transaction : ${result.digest}`
-    );
     await client.waitForTransaction({ digest: result.digest });
     log(
       NetworkID.Sui,
@@ -58,7 +46,7 @@ export const suiWithdraw = async ({
       )} SUI tokens from the Gateway to ${sender}`
     );
   } catch (e) {
-    console.log(`failed to withdraw: ${e}`);
+    log(NetworkID.Sui, `failed to withdraw: ${e}`);
     throw e;
   }
 };

--- a/packages/localnet/src/suiWithdraw.ts
+++ b/packages/localnet/src/suiWithdraw.ts
@@ -50,7 +50,8 @@ export const suiWithdraw = async ({
     const status = txDetails.effects?.status?.status;
     if (status !== "success") {
       const errorMessage = txDetails.effects?.status?.error;
-      throw new Error(`Transaction ${result.digest} failed: ${errorMessage}, status ${status}`);
+      throw new Error(`
+        Transaction ${result.digest} failed: ${errorMessage}, status ${status}`);
     }
 
     log(

--- a/packages/localnet/src/suiWithdrawAndCall.ts
+++ b/packages/localnet/src/suiWithdrawAndCall.ts
@@ -1,0 +1,106 @@
+import { Transaction } from "@mysten/sui/transactions";
+import { ethers } from "ethers";
+
+import { NetworkID } from "./constants";
+import { log } from "./log";
+
+export const suiWithdrawAndCall = async ({
+  amount,
+  targetModule,
+  client,
+  keypair,
+  moduleId,
+  gatewayObjectId,
+  withdrawCapObjectId,
+}: any) => {
+  const nonce = await fetchGatewayNonce(client, gatewayObjectId);
+  const tx = new Transaction();
+  const coinType =
+    "0000000000000000000000000000000000000000000000000000000000000002::sui::SUI";
+
+  // Withdraw the coins and get the coins ID
+  const [coins, coinsBudget] = tx.moveCall({
+    arguments: [
+      tx.object(gatewayObjectId),
+      tx.pure.u64(amount),
+      tx.pure.u64(nonce),
+      tx.pure.u64(100000),
+      tx.object(withdrawCapObjectId),
+    ],
+    target: `${moduleId}::gateway::withdraw_impl`,
+    typeArguments: [coinType],
+  });
+
+  // Transfer the amount for budget to the TSS
+  tx.transferObjects([coinsBudget], tx.pure.address(keypair.getPublicKey().toSuiAddress()));
+
+  // Call the target contract on_call
+  // Sample arguments for now
+  tx.moveCall({
+    arguments: [
+      coins,
+      tx.pure.u64(42),
+    ],
+    target: `${targetModule}::universal::on_call`,
+    typeArguments: [coinType],
+  });
+
+  tx.setGasBudget(100000000)
+
+  log(
+    NetworkID.Sui,
+    `Calling module ${targetModule}::universal::on_call with coins  ${JSON.stringify(coins, null, 2)}`
+  );
+
+  try {
+    log(
+      NetworkID.Sui,
+      `WithdrawAndCall ${amount} SUI tokens from the Gateway to ${targetModule}`
+    );
+
+    const result = await await client.signAndExecuteTransaction({
+      signer: keypair,
+      transaction: tx,
+    });
+
+    log(
+      NetworkID.Sui,
+      `Withdrawing SUI tokens from the Gateway transaction : ${result.digest}`
+    );
+
+    await client.waitForTransaction({ digest: result.digest });
+    log(
+      NetworkID.Sui,
+      `Withdrawing SUI tokens from the Gateway to succeeded`
+    );
+
+  } catch (e) {
+    console.log(`failed to withdrawAndCall: ${e}`);
+    throw e;
+  }
+
+  log(
+    NetworkID.Sui,
+    `Withdrawing ${ethers.formatUnits(
+      amount,
+      9
+    )} SUI tokens from the Gateway`
+  );
+};
+
+const fetchGatewayNonce = async (client: any, gatewayId: string) => {
+  const resp = await client.getObject({
+    id: gatewayId,
+    options: { showContent: true },
+  });
+
+  if (resp.data?.content?.dataType !== "moveObject") {
+    throw new Error("Not a valid Move object");
+  }
+
+  const fields = (resp.data.content as any).fields;
+  const nonceValue = fields.nonce;
+
+  console.log("Gateway nonce:", nonceValue);
+  return nonceValue;
+};

--- a/packages/localnet/src/suiWithdrawAndCall.ts
+++ b/packages/localnet/src/suiWithdrawAndCall.ts
@@ -34,13 +34,14 @@ export const suiWithdrawAndCall = async ({
     });
 
     // transfer the amount for budget to the TSS
-    tx.transferObjects([coinsBudget], tx.pure.address(keypair.getPublicKey().toSuiAddress()));
+    tx.transferObjects(
+      [coinsBudget],
+      tx.pure.address(keypair.getPublicKey().toSuiAddress())
+    );
 
     // prepare on call arguments
     const decodedMessage = AbiCoder.defaultAbiCoder().decode(
-      [
-        "tuple(string[] typeArguments, bytes32[] objects, bytes data)",
-      ],
+      ["tuple(string[] typeArguments, bytes32[] objects, bytes data)"],
       message
     )[0];
     const additionalTypeArguments = decodedMessage[0];
@@ -63,8 +64,7 @@ export const suiWithdrawAndCall = async ({
       target: `${targetModule}::universal::on_call`,
       typeArguments: onCallTypeArguments,
     });
-    tx.setGasBudget(100000000)
-
+    tx.setGasBudget(100000000);
 
     // send the transaction and wait for it
     const result = await await client.signAndExecuteTransaction({
@@ -85,7 +85,9 @@ export const suiWithdrawAndCall = async ({
     const status = txDetails.effects?.status?.status;
     if (status !== "success") {
       const errorMessage = txDetails.effects?.status?.error;
-      throw new Error(`Transaction ${result.digest} failed: ${errorMessage}, status ${status}`);
+      throw new Error(
+        `Transaction ${result.digest} failed: ${errorMessage}, status ${status}`
+      );
     }
 
     log(

--- a/packages/localnet/src/suiWithdrawAndCall.ts
+++ b/packages/localnet/src/suiWithdrawAndCall.ts
@@ -44,48 +44,25 @@ export const suiWithdrawAndCall = async ({
     target: `${targetModule}::universal::on_call`,
     typeArguments: [coinType],
   });
-
   tx.setGasBudget(100000000)
 
-  log(
-    NetworkID.Sui,
-    `Calling module ${targetModule}::universal::on_call with coins  ${JSON.stringify(coins, null, 2)}`
-  );
-
   try {
-    log(
-      NetworkID.Sui,
-      `WithdrawAndCall ${amount} SUI tokens from the Gateway to ${targetModule}`
-    );
-
     const result = await await client.signAndExecuteTransaction({
       signer: keypair,
       transaction: tx,
     });
-
-    log(
-      NetworkID.Sui,
-      `Withdrawing SUI tokens from the Gateway transaction : ${result.digest}`
-    );
-
     await client.waitForTransaction({ digest: result.digest });
     log(
       NetworkID.Sui,
-      `Withdrawing SUI tokens from the Gateway to succeeded`
+      `Withdrawing ${ethers.formatUnits(
+        amount,
+        9
+      )} SUI tokens and calling contract from the Gateway to ${gatewayObjectId}`
     );
-
   } catch (e) {
-    console.log(`failed to withdrawAndCall: ${e}`);
+    log(NetworkID.Sui, `failed to withdraw and call: ${e}`);
     throw e;
   }
-
-  log(
-    NetworkID.Sui,
-    `Withdrawing ${ethers.formatUnits(
-      amount,
-      9
-    )} SUI tokens from the Gateway`
-  );
 };
 
 const fetchGatewayNonce = async (client: any, gatewayId: string) => {

--- a/packages/localnet/src/suiWithdrawAndCall.ts
+++ b/packages/localnet/src/suiWithdrawAndCall.ts
@@ -48,6 +48,7 @@ export const suiWithdrawAndCall = async ({
     const data = decodedMessage[2];
 
     // TODO: check all objects are shared and not owned by the sender
+    // https://github.com/zeta-chain/localnet/issues/134
 
     const onCallTypeArguments = [coinType, ...additionalTypeArguments];
     const onCallArguments = [

--- a/packages/localnet/src/suiWithdrawAndCall.ts
+++ b/packages/localnet/src/suiWithdrawAndCall.ts
@@ -61,7 +61,7 @@ export const suiWithdrawAndCall = async ({
     // call the target contract on_call
     tx.moveCall({
       arguments: onCallArguments,
-      target: `${targetModule}::universal::on_call`,
+      target: `${targetModule}::connected::on_call`,
       typeArguments: onCallTypeArguments,
     });
     tx.setGasBudget(100000000);

--- a/packages/localnet/src/suiWithdrawAndCall.ts
+++ b/packages/localnet/src/suiWithdrawAndCall.ts
@@ -1,5 +1,5 @@
 import { Transaction } from "@mysten/sui/transactions";
-import { ethers } from "ethers";
+import { AbiCoder, ethers } from "ethers";
 
 import { NetworkID } from "./constants";
 import { log } from "./log";
@@ -7,6 +7,7 @@ import { log } from "./log";
 export const suiWithdrawAndCall = async ({
   amount,
   targetModule,
+  message,
   client,
   keypair,
   moduleId,
@@ -17,6 +18,20 @@ export const suiWithdrawAndCall = async ({
   const tx = new Transaction();
   const coinType =
     "0000000000000000000000000000000000000000000000000000000000000002::sui::SUI";
+
+  // Decode the message
+  const decodedBytes = AbiCoder.defaultAbiCoder().decode(["bytes"], message);
+  const decodedMessage = AbiCoder.defaultAbiCoder().decode(
+    [
+      "tuple(string[] typeArguments, byte32[] objects, bytes message)",
+    ],
+    decodedBytes[0]
+  )[0];
+  const additionalTypeArguments = decodedMessage[0];
+  const objects = decodedMessage[1];
+  const data = decodedMessage[2];
+
+  // TODO: check all objects are shared and not owned by the sender
 
   // Withdraw the coins and get the coins ID
   const [coins, coinsBudget] = tx.moveCall({

--- a/packages/localnet/src/suiWithdrawAndCall.ts
+++ b/packages/localnet/src/suiWithdrawAndCall.ts
@@ -81,8 +81,6 @@ export const suiWithdrawAndCall = async ({
         showEffects: true,
       },
     });
-    // console.log("txDetails")
-    console.dir(txDetails.effects, { depth: null });
     const status = txDetails.effects?.status?.status;
     if (status !== "success") {
       const errorMessage = txDetails.effects?.status?.error;

--- a/packages/localnet/src/zetachainWithdraw.ts
+++ b/packages/localnet/src/zetachainWithdraw.ts
@@ -51,7 +51,7 @@ export const zetachainWithdraw = async ({
       await suiWithdraw({
         amount,
         sender: receiver,
-        ...contracts.suiContracts,
+        ...contracts.suiContracts.env,
       });
     } else {
       if (isGasToken) {

--- a/packages/localnet/src/zetachainWithdrawAndCall.ts
+++ b/packages/localnet/src/zetachainWithdrawAndCall.ts
@@ -8,6 +8,7 @@ import { evmExecute } from "./evmExecute";
 import { log, logErr } from "./log";
 import { solanaExecute } from "./solanaExecute";
 import { zetachainOnRevert } from "./zetachainOnRevert";
+import { suiWithdrawAndCall } from "./suiWithdrawAndCall";
 
 export const zetachainWithdrawAndCall = async ({
   args,
@@ -64,7 +65,15 @@ export const zetachainWithdrawAndCall = async ({
         });
         break;
       }
-      // current case in default, it will be extended with other chains in future
+      // sui
+      case NetworkID.Sui: {
+        await suiWithdrawAndCall({
+          amount,
+          targetModule: receiver,
+          ...contracts.suiContracts.env,
+        });
+        break;
+      }
       default: {
         if (isArbitraryCall) {
           const selector = message.slice(0, 10);

--- a/packages/localnet/src/zetachainWithdrawAndCall.ts
+++ b/packages/localnet/src/zetachainWithdrawAndCall.ts
@@ -69,6 +69,7 @@ export const zetachainWithdrawAndCall = async ({
       case NetworkID.Sui: {
         await suiWithdrawAndCall({
           amount,
+          message,
           targetModule: receiver,
           ...contracts.suiContracts.env,
         });

--- a/packages/localnet/src/zetachainWithdrawAndCall.ts
+++ b/packages/localnet/src/zetachainWithdrawAndCall.ts
@@ -7,8 +7,8 @@ import { evmCustodyWithdrawAndCall } from "./evmCustodyWithdrawAndCall";
 import { evmExecute } from "./evmExecute";
 import { log, logErr } from "./log";
 import { solanaExecute } from "./solanaExecute";
-import { zetachainOnRevert } from "./zetachainOnRevert";
 import { suiWithdrawAndCall } from "./suiWithdrawAndCall";
+import { zetachainOnRevert } from "./zetachainOnRevert";
 
 export const zetachainWithdrawAndCall = async ({
   args,


### PR DESCRIPTION
Closes https://github.com/zeta-chain/localnet/issues/114

It has been tested with an advanced example using https://github.com/lumtis/sui-zeta

In progress, needs some refinements to determine how the payload is parsed for the onCall argument.

Tested with https://github.com/lumtis/sui-zeta/blob/main/sources/suizeta.move

### Conditions

- The contract must have a type argument representing the token type (we might possible allow other type argument to extend usability)
- First argument is the withdrawn coin
- Other argument must be shared object or pure
- The function must be called `on_call`, the name of the file must be `universal`, when doing withdraw and call, the package ID is provided as a target, it calls
```
${target}::universal::on_call
```

```
public entry fun on_call<COIN_TYPE>(
    coins: Coin<COIN_TYPE>,
    _randomValue: u64,
    ctx: &mut TxContext,
)
```

### To test:

Run localnet
```
npx hardhat localnet --skip solana
```

Deploy the Sui contract, example above with:
```
sui client publish
```

Deposit some Sui
```
sui client call \
  --package <package> \
  --module gateway \
  --function deposit \
  --type-args 0x2::sui::SUI \
  --args <gateway> \
   <coin_id> \
    0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
```

Withdraw and call
```
cast send 0xd97B1de3619ed2c6BEb3860147E30cA8A7dC9891 "approve(address,uint256)" 0x5FC8d32690cc91D4c39d9d3abcBD16989F875707 1000000000000000000000000 --private-key <>

cast send 0x5FC8d32690cc91D4c39d9d3abcBD16989F875707 "withdraw(bytes,uint256,address,(address,bool,address,bytes,uint256))" \
  "<target package>" \
  "1000000" \
  "0xd97B1de3619ed2c6BEb3860147E30cA8A7dC9891" \
  "(0xB0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,true,0xC0b86991c6218b36c1d19D4a2e9Eb0cE3606eB49,0xdeadbeef,50000)" \
  --private-key <>
  
```