### PR TITLE
fix: ZetaChain deposit/deposit & call not being able to find foreign asset

### DIFF
--- a/packages/localnet/src/zetachainDeposit.ts
+++ b/packages/localnet/src/zetachainDeposit.ts
@@ -33,8 +33,7 @@ export const zetachainDeposit = async ({
     } else {
       foreignCoin = foreignCoins.find(
         (coin: any) =>
-          coin.foreign_chain_id === chainID &&
-          coin.coin_type === asset.toString()
+          coin.foreign_chain_id === chainID && coin.asset === asset.toString()
       );
     }
   }

--- a/packages/localnet/src/zetachainDepositAndCall.ts
+++ b/packages/localnet/src/zetachainDepositAndCall.ts
@@ -33,8 +33,7 @@ export const zetachainDepositAndCall = async ({
     } else {
       foreignCoin = foreignCoins.find(
         (coin: any) =>
-          coin.foreign_chain_id === chainID &&
-          coin.coin_type === asset.toString()
+          coin.foreign_chain_id === chainID && coin.asset === asset.toString()
       );
     }
   }


### PR DESCRIPTION
For some reason `asset` was compared with `coin_type` when looking up a foreign coin, which resulted in:

```
[ZetaChain]: Foreign coin not found for asset: 0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f
```

This fixes the issue.