### PR TITLE
fix: set non-EVM sender address correctly

### DIFF
--- a/src/chains/sui/depositAndCall.ts
+++ b/src/chains/sui/depositAndCall.ts
@@ -49,6 +49,9 @@ export const suiDepositAndCall = async ({
       zetachainContracts,
     });
   } catch (e) {
+    logger.error(`depositAndCall failed: ${e}`, {
+      chain: NetworkID.ZetaChain,
+    });
     const { revertGasFee } = await zetachainSwapToCoverGas({
       amount: event.amount,
       asset,

--- a/src/chains/zetachain/depositAndCall.ts
+++ b/src/chains/zetachain/depositAndCall.ts
@@ -52,7 +52,7 @@ export const zetachainDepositAndCall = async ({
   const context = {
     chainID,
     sender: sender,
-    senderEVM: nonEVM.includes(chainID) ? sender : ethers.ZeroAddress,
+    senderEVM: nonEVM.includes(chainID) ? ethers.ZeroAddress : sender,
   };
 
   logger.info(

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -36,7 +36,8 @@ const chainFormat = winston.format.printf(({ level, message, chain }) => {
   const chainDetails = chains[chain as string];
   const color = chainDetails?.color || ansis.black;
   const chainName = chainDetails?.name || `Unknown Chain (${chain})`;
-  return `${color(`[${ansis.bold(chainName)}]`)} ${color(message)}`;
+  const messageColor = level === "error" ? ansis.red : color;
+  return `${color(`[${ansis.bold(chainName)}]`)} ${messageColor(message)}`;
 });
 
 export let logger: winston.Logger;


### PR DESCRIPTION
* set non-EVM sender address correctly when depositing and calling
* `logger.error` now prints in red
* log error when deposit and call fails when triggered from Sui

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected logic for sender address assignment in deposit and call operations for better chain compatibility.

- **Style**
  - Improved log message formatting to highlight errors in red, making them easier to identify.

- **Chores**
  - Enhanced error logging for deposit and call failures to provide clearer diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->