### PR TITLE
fix: do not stop TON if it has not been enabled

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -250,7 +250,7 @@ const startLocalnet = async (options: {
     process.exit(0);
   }
 
-  if (!enabledChains.includes("ton")) {
+  if (enabledChains.includes("ton")) {
     await waitForTonContainerToStop();
   }
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the logic to ensure the app waits for the TON container to stop only when the TON chain is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->