### PR TITLE
refactor: remove uniswap v3

### DIFF
--- a/src/chains/zetachain/setup.ts
+++ b/src/chains/zetachain/setup.ts
@@ -30,10 +30,7 @@ export const zetachainSetup = async (
   const wzeta = await weth9Factory.deploy(deployOpts);
 
   // Setup both Uniswap V2 and V3
-  const [v2Setup, v3Setup] = await Promise.all([
-    prepareUniswapV2(deployer, wzeta),
-    prepareUniswapV3(deployer, wzeta),
-  ]);
+  const v2Setup = await prepareUniswapV2(deployer, wzeta);
 
   const [
     uniswapFactoryInstanceAddress,
@@ -111,9 +108,6 @@ export const zetachainSetup = async (
     tss,
     uniswapFactoryInstance: v2Setup.uniswapFactoryInstance,
     uniswapRouterInstance: v2Setup.uniswapRouterInstance,
-    uniswapV3Factory: v3Setup.uniswapV3FactoryInstance,
-    uniswapV3PositionManager: v3Setup.nonfungiblePositionManagerInstance,
-    uniswapV3Router: v3Setup.swapRouterInstance,
     wzeta,
   };
 };

--- a/src/tokens/createToken.ts
+++ b/src/tokens/createToken.ts
@@ -49,8 +49,6 @@ export const createToken = async (
     gatewayZEVM,
     uniswapFactoryInstance,
     uniswapRouterInstance,
-    uniswapV3Factory,
-    uniswapV3PositionManager,
     wzeta,
     fungibleModuleSigner,
   } = contracts.zetachainContracts;
@@ -187,25 +185,13 @@ export const createToken = async (
       .deposit({ value: ethers.parseEther("1000"), ...deployOpts }),
   ]);
 
-  await Promise.all([
-    uniswapV2AddLiquidity(
-      uniswapRouterInstance,
-      uniswapFactoryInstance,
-      zrc20,
-      wzeta,
-      deployer,
-      zrc20Amount,
-      wzetaAmount
-    ),
-
-    uniswapV3AddLiquidity(
-      zrc20,
-      wzeta,
-      deployer,
-      zrc20Amount,
-      wzetaAmount,
-      uniswapV3Factory,
-      uniswapV3PositionManager
-    ),
-  ]);
+  await uniswapV2AddLiquidity(
+    uniswapRouterInstance,
+    uniswapFactoryInstance,
+    zrc20,
+    wzeta,
+    deployer,
+    zrc20Amount,
+    wzetaAmount
+  );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified token creation and setup processes by removing support for Uniswap V3. All related steps and references to Uniswap V3 have been eliminated, streamlining operations to use only Uniswap V2 for liquidity provisioning. No changes to user-facing interfaces or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->