### PR TITLE
fix: mint SPL-20 tokens to account derived from default mnemonic

### DIFF
--- a/src/chains/solana/setup.ts
+++ b/src/chains/solana/setup.ts
@@ -111,6 +111,13 @@ export const solanaSetup = async ({
     }
   );
 
+  logger.info(
+    `Public Key from default mnemonic: ${defaultLocalnetUserKeypair.publicKey.toBase58()}`,
+    {
+      chain: NetworkID.Solana,
+    }
+  );
+
   const gatewayProgram = new anchor.Program(Gateway_IDL as anchor.Idl);
 
   try {
@@ -205,6 +212,7 @@ export const solanaSetup = async ({
     ],
     env: {
       defaultSolanaUser: defaultSolanaUserKeypair,
+      defaultLocalnetUser: defaultLocalnetUserKeypair,
       gatewayProgram,
     },
   };

--- a/src/chains/solana/setup.ts
+++ b/src/chains/solana/setup.ts
@@ -211,8 +211,8 @@ export const solanaSetup = async ({
       },
     ],
     env: {
-      defaultSolanaUser: defaultSolanaUserKeypair,
       defaultLocalnetUser: defaultLocalnetUserKeypair,
+      defaultSolanaUser: defaultSolanaUserKeypair,
       gatewayProgram,
     },
   };

--- a/src/tokens/createSolanaToken.ts
+++ b/src/tokens/createSolanaToken.ts
@@ -43,28 +43,38 @@ export const createSolanaToken = async (env: any, decimals: number) => {
     GATEWAY_PROGRAM_ID
   );
 
-  const [gatewayTokenAccount, tssTokenAccount, userTokenAccount] =
-    await Promise.all([
-      getOrCreateAssociatedTokenAccount(
-        env.gatewayProgram.provider.connection,
-        tssKeypair,
-        mint,
-        gatewayPDA,
-        true // allowOwnerOffCurve = true, because gatewayPDA is a program-derived address
-      ),
-      getOrCreateAssociatedTokenAccount(
-        env.gatewayProgram.provider.connection,
-        tssKeypair,
-        mint,
-        tssKeypair.publicKey
-      ),
-      getOrCreateAssociatedTokenAccount(
-        env.gatewayProgram.provider.connection,
-        env.defaultSolanaUser,
-        mint,
-        env.defaultSolanaUser.publicKey
-      ),
-    ]);
+  const [
+    gatewayTokenAccount,
+    tssTokenAccount,
+    userTokenAccount,
+    localnetTokenAccount,
+  ] = await Promise.all([
+    getOrCreateAssociatedTokenAccount(
+      env.gatewayProgram.provider.connection,
+      tssKeypair,
+      mint,
+      gatewayPDA,
+      true // allowOwnerOffCurve = true, because gatewayPDA is a program-derived address
+    ),
+    getOrCreateAssociatedTokenAccount(
+      env.gatewayProgram.provider.connection,
+      tssKeypair,
+      mint,
+      tssKeypair.publicKey
+    ),
+    getOrCreateAssociatedTokenAccount(
+      env.gatewayProgram.provider.connection,
+      env.defaultSolanaUser,
+      mint,
+      env.defaultSolanaUser.publicKey
+    ),
+    getOrCreateAssociatedTokenAccount(
+      env.gatewayProgram.provider.connection,
+      env.defaultLocalnetUser,
+      mint,
+      env.defaultLocalnetUser.publicKey
+    ),
+  ]);
 
   await Promise.all([
     mintTo(
@@ -89,6 +99,14 @@ export const createSolanaToken = async (env: any, decimals: number) => {
       tssKeypair,
       mint,
       gatewayTokenAccount.address,
+      tssKeypair.publicKey,
+      100 * LAMPORTS_PER_SOL
+    ),
+    mintTo(
+      env.gatewayProgram.provider.connection,
+      tssKeypair,
+      mint,
+      localnetTokenAccount.address,
       tssKeypair.publicKey,
       100 * LAMPORTS_PER_SOL
     ),


### PR DESCRIPTION
This is just a quick fix to mint some SPL-20 tokens to default account. In general, we need to migrate localnet to the account system used in the Toolkit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved visibility into the Solana environment by displaying the public key derived from the default mnemonic keypair.
  - The default localnet user keypair is now accessible in the environment for broader usability.
  - Token creation now includes support for an additional user account, ensuring tokens are minted to this new account as well.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->