### PR TITLE
refactor: use native ZETA instead of WZETA in the deposit flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@uniswap/v3-core": "^1.0.1",
     "@uniswap/v3-periphery": "^1.4.4",
     "@uniswap/v3-sdk": "^3.25.2",
-    "@zetachain/protocol-contracts": "13.1.0-rc2",
+    "@zetachain/protocol-contracts": "13.1.0-rc3",
     "@zetachain/protocol-contracts-ton": "1.0.0-rc3",
     "ansis": "^3.3.2",
     "bip39": "^3.1.0",

--- a/src/chains/zetachain/depositAndCallZeta.ts
+++ b/src/chains/zetachain/depositAndCallZeta.ts
@@ -21,13 +21,13 @@ export const zetachainDepositAndCallZeta = async ({
   logger.info(
     `Universal contract ${receiver} executing onCall (context: ${JSON.stringify(
       context
-    )}), WZETA, amount: ${amount}, message: ${message})`,
+    )}), ZETA, amount: ${amount}, message: ${message})`,
     { chain: NetworkID.ZetaChain }
   );
 
   const tx = await zetachainContracts.gatewayZEVM
     .connect(zetachainContracts.fungibleModuleSigner)
-    .depositAndCall(context, amount, receiver, message);
+    .depositAndCall(context, receiver, message, { value: amount });
   await tx.wait();
 
   const logs = await provider.getLogs({

--- a/src/chains/zetachain/depositZeta.ts
+++ b/src/chains/zetachain/depositZeta.ts
@@ -8,9 +8,9 @@ export const zetachainDepositZeta = async ({
   const [, receiver, amount] = args;
   const tx = await zetachainContracts.gatewayZEVM
     .connect(zetachainContracts.fungibleModuleSigner)
-    .deposit(amount, receiver);
+    .deposit(receiver, { value: amount });
   await tx.wait();
-  logger.info(`Deposited ${amount} of WZETA tokens to ${receiver}`, {
+  logger.info(`Deposited ${amount} of ZETA tokens to ${receiver}`, {
     chain: NetworkID.ZetaChain,
   });
   return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1609,10 +1609,10 @@
   dependencies:
     ethers "^6.13.2"
 
-"@zetachain/protocol-contracts@13.1.0-rc2":
-  version "13.1.0-rc2"
-  resolved "https://registry.yarnpkg.com/@zetachain/protocol-contracts/-/protocol-contracts-13.1.0-rc2.tgz#f8de4ceafdc3968b860579a5f082de5609137c72"
-  integrity sha512-EArk6pTLhV1xG8Yy9sYceBhS3/MpIFiwqyVJq31vIv2NrcG0OvbweMRiRVRMC7RbKb4wwR/9eEKqF4AdaQzKsA==
+"@zetachain/protocol-contracts@13.1.0-rc3":
+  version "13.1.0-rc3"
+  resolved "https://registry.yarnpkg.com/@zetachain/protocol-contracts/-/protocol-contracts-13.1.0-rc3.tgz#23e637dd53147701033f50079ce0b93f8c14cf37"
+  integrity sha512-8nrIOOBl2PXt6TNkrSDjqZxJwd2u8PmQKY3vJo0a4gQgCoKYT44gGvLk8TVp8cjnP/OJStbmIQt/NKZhk1188g==
   dependencies:
     "@openzeppelin/contracts" "^5.0.2"
     "@openzeppelin/contracts-upgradeable" "^5.0.2"


### PR DESCRIPTION
Use native ZETA instead of WZETA in deposit flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated transaction handling for ZETA deposits to ensure correct processing and logging.
	- Log messages now consistently refer to "ZETA" tokens instead of "WZETA."

- **Chores**
	- Upgraded the "@zetachain/protocol-contracts" dependency to version 13.1.0-rc3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->