### PR TITLE
feat: update scripts to adopt Sui authenticated call

### DIFF
--- a/src/chains/sui/suiSetup.ts
+++ b/src/chains/sui/suiSetup.ts
@@ -235,10 +235,10 @@ export const suiSetup = async ({
       client,
       gatewayObjectId,
       keypair,
+      messageContextObjectId,
       packageId,
       whitelistCapObjectId,
       withdrawCapObjectId,
-      messageContextObjectId,
     },
   };
 };

--- a/src/chains/sui/suiSetup.ts
+++ b/src/chains/sui/suiSetup.ts
@@ -183,10 +183,17 @@ export const suiSetup = async ({
       change.objectType.includes("gateway::WhitelistCap")
   );
 
+  const messageContextObject = publishResult.objectChanges?.find(
+    (change: any) =>
+      change.type === "created" &&
+      change.objectType.includes("gateway::MessageContext")
+  );
+
   const packageId = (publishedModule as any).packageId;
   const gatewayObjectId = (gatewayObject as any).objectId;
   const withdrawCapObjectId = (withdrawCapObject as any).objectId;
   const whitelistCapObjectId = (whitelistCapObject as any).objectId;
+  const messageContextObjectId = (messageContextObject as any).objectId;
 
   pollEvents({
     client,
@@ -231,6 +238,7 @@ export const suiSetup = async ({
       packageId,
       whitelistCapObjectId,
       withdrawCapObjectId,
+      messageContextObjectId,
     },
   };
 };

--- a/src/chains/sui/suiSetup.ts
+++ b/src/chains/sui/suiSetup.ts
@@ -198,11 +198,11 @@ export const suiSetup = async ({
 
   // issue and add message context ID as gateway dynamic field
   const messageContextObjectId = await issueMessageContext({
+    adminCapObjectId,
     client,
+    gatewayObjectId,
     keypair,
     packageId,
-    gatewayObjectId,
-    adminCapObjectId,
   });
 
   pollEvents({
@@ -376,25 +376,22 @@ const ensureDirectoryExists = () => {
 };
 
 const issueMessageContext = async ({
+  adminCapObjectId,
   client,
+  gatewayObjectId,
   keypair,
   packageId,
-  gatewayObjectId,
-  adminCapObjectId,
 }: {
+  adminCapObjectId: string;
   client: SuiClient;
+  gatewayObjectId: string;
   keypair: Ed25519Keypair;
   packageId: string;
-  gatewayObjectId: string;
-  adminCapObjectId: string;
 }): Promise<string> => {
   const tx = new Transaction();
 
   tx.moveCall({
-    arguments: [
-      tx.object(gatewayObjectId),
-      tx.object(adminCapObjectId),
-    ],
+    arguments: [tx.object(gatewayObjectId), tx.object(adminCapObjectId)],
     target: `${packageId}::gateway::issue_message_context`,
   });
 
@@ -433,10 +430,14 @@ const issueMessageContext = async ({
     }
 
     const messageContextObjectId = (messageContextObject as any).objectId;
-    logger.info(`MessageContext ID: ${messageContextObjectId}`, { chain: NetworkID.Sui });
+    logger.info(`MessageContext ID: ${messageContextObjectId}`, {
+      chain: NetworkID.Sui,
+    });
     return messageContextObjectId;
   } catch (e) {
-    logger.error(`Failed to issue MessageContext: ${e}`, { chain: NetworkID.Sui });
+    logger.error(`Failed to issue MessageContext: ${e}`, {
+      chain: NetworkID.Sui,
+    });
     throw e;
   }
 };

--- a/src/chains/sui/suiSetup.ts
+++ b/src/chains/sui/suiSetup.ts
@@ -1,6 +1,7 @@
 import { EventId, SuiClient } from "@mysten/sui/client";
 import { requestSuiFromFaucetV0 } from "@mysten/sui/faucet";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { Transaction } from "@mysten/sui/transactions";
 import { mnemonicToSeedSync } from "bip39";
 import { execSync, spawnSync } from "child_process";
 import { HDKey } from "ethereum-cryptography/hdkey";
@@ -183,17 +184,26 @@ export const suiSetup = async ({
       change.objectType.includes("gateway::WhitelistCap")
   );
 
-  const messageContextObject = publishResult.objectChanges?.find(
+  const adminCapObject = publishResult.objectChanges?.find(
     (change: any) =>
       change.type === "created" &&
-      change.objectType.includes("gateway::MessageContext")
+      change.objectType.includes("gateway::AdminCap")
   );
 
   const packageId = (publishedModule as any).packageId;
   const gatewayObjectId = (gatewayObject as any).objectId;
   const withdrawCapObjectId = (withdrawCapObject as any).objectId;
   const whitelistCapObjectId = (whitelistCapObject as any).objectId;
-  const messageContextObjectId = (messageContextObject as any).objectId;
+  const adminCapObjectId = (adminCapObject as any).objectId;
+
+  // issue and add message context ID as gateway dynamic field
+  const messageContextObjectId = await issueMessageContext({
+    client,
+    keypair,
+    packageId,
+    gatewayObjectId,
+    adminCapObjectId,
+  });
 
   pollEvents({
     client,
@@ -362,5 +372,71 @@ const ensureDirectoryExists = () => {
     );
     runSudoCommand("chown", ["-R", os.userInfo().username, LOCALNET_DIR]);
     logger.info("Ownership updated.", { chain: NetworkID.Sui });
+  }
+};
+
+const issueMessageContext = async ({
+  client,
+  keypair,
+  packageId,
+  gatewayObjectId,
+  adminCapObjectId,
+}: {
+  client: SuiClient;
+  keypair: Ed25519Keypair;
+  packageId: string;
+  gatewayObjectId: string;
+  adminCapObjectId: string;
+}): Promise<string> => {
+  const tx = new Transaction();
+
+  tx.moveCall({
+    arguments: [
+      tx.object(gatewayObjectId),
+      tx.object(adminCapObjectId),
+    ],
+    target: `${packageId}::gateway::issue_message_context`,
+  });
+
+  try {
+    // send the transaction
+    const result = await client.signAndExecuteTransaction({
+      signer: keypair,
+      transaction: tx,
+    });
+    await client.waitForTransaction({ digest: result.digest });
+
+    // check if the tx has succeeded
+    const txDetails = await client.getTransactionBlock({
+      digest: result.digest,
+      options: {
+        showEffects: true,
+        showObjectChanges: true,
+      },
+    });
+    const status = txDetails.effects?.status?.status;
+    if (status !== "success") {
+      const errorMessage = txDetails.effects?.status?.error;
+      throw new Error(`
+        Transaction ${result.digest} failed: ${errorMessage}, status ${status}`);
+    }
+
+    // find the newly created MessageContext object
+    const messageContextObject = txDetails.objectChanges?.find(
+      (change: any) =>
+        change.type === "created" &&
+        change.objectType.includes("gateway::MessageContext")
+    );
+
+    if (!messageContextObject) {
+      throw new Error("Failed to find created MessageContext object");
+    }
+
+    const messageContextObjectId = (messageContextObject as any).objectId;
+    logger.info(`MessageContext ID: ${messageContextObjectId}`, { chain: NetworkID.Sui });
+    return messageContextObjectId;
+  } catch (e) {
+    logger.error(`Failed to issue MessageContext: ${e}`, { chain: NetworkID.Sui });
+    throw e;
   }
 };

--- a/src/chains/zetachain/withdrawAndCall.ts
+++ b/src/chains/zetachain/withdrawAndCall.ts
@@ -87,9 +87,9 @@ export const zetachainWithdrawAndCall = async ({
       // sui
       case NetworkID.Sui: {
         await suiWithdrawAndCall({
-          sender,
           amount,
           message,
+          sender,
           targetModule: receiver,
           ...contracts.suiContracts.env,
         });

--- a/src/chains/zetachain/withdrawAndCall.ts
+++ b/src/chains/zetachain/withdrawAndCall.ts
@@ -87,6 +87,7 @@ export const zetachainWithdrawAndCall = async ({
       // sui
       case NetworkID.Sui: {
         await suiWithdrawAndCall({
+          sender,
           amount,
           message,
           targetModule: receiver,


### PR DESCRIPTION
This PR adopts Sui gateway message context for authenticated call [PR 65](https://github.com/zeta-chain/protocol-contracts-sui/pull/65).

The `./scripts/test-cli-npx-integration.sh` runs well with option `--chains sui`.

<img width="732" height="467" alt="image" src="https://github.com/user-attachments/assets/1fee8124-2bfb-40c3-b2c4-23e959ea66ae" />


Closes: https://github.com/zeta-chain/localnet/issues/199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sui transactions now create and manage a Message Context object and pass sender information to relevant operations.
  * Automatic discovery of admin capability objects to enable message context issuance.

* **Bug Fixes**
  * More reliable contract calls by explicitly setting and resetting message context around withdraw-and-call flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->