### PR TITLE
fix: compatibility with Foundry >= v1.2.3

### DIFF
--- a/src/chains/zetachain/initRegistry.ts
+++ b/src/chains/zetachain/initRegistry.ts
@@ -2,6 +2,7 @@ import * as ZRC20 from "@zetachain/protocol-contracts/abi/ZRC20.sol/ZRC20.json";
 import { ethers } from "ethers";
 
 import { NetworkID } from "../../constants";
+import { deployOpts } from "../../deployOpts";
 import { logger } from "../../logger";
 import { setRegistryInitComplete } from "../../types/registryState";
 import { sleep } from "../../utils";
@@ -338,7 +339,8 @@ const approveAllZRC20GasTokens = async ({
     try {
       const approveTx = await gasZRC20Contract.approve(
         coreRegistry.target,
-        MAX_UINT256
+        MAX_UINT256,
+        deployOpts
       );
       await approveTx.wait();
     } catch (err: any) {

--- a/src/tokens/uniswapV3.ts
+++ b/src/tokens/uniswapV3.ts
@@ -259,7 +259,6 @@ export const addLiquidityV3 = async (
     token1,
   };
 
-  // Provide manual gas to avoid estimateGas failures on anvil 1.3.x
   const tx = await nonfungiblePositionManager.mint(params, deployOpts);
   const receipt = await tx.wait();
 

--- a/src/tokens/uniswapV3.ts
+++ b/src/tokens/uniswapV3.ts
@@ -28,6 +28,15 @@ export const prepareUniswapV3 = async (deployer: Signer, wzeta: any) => {
   const uniswapV3FactoryInstance = await uniswapV3Factory.deploy(deployOpts);
   await uniswapV3FactoryInstance.waitForDeployment();
 
+  // Ensure common fee tiers are enabled explicitly
+  await (uniswapV3FactoryInstance as any).enableFeeAmount(500, 10, deployOpts);
+  await (uniswapV3FactoryInstance as any).enableFeeAmount(3000, 60, deployOpts);
+  await (uniswapV3FactoryInstance as any).enableFeeAmount(
+    10000,
+    200,
+    deployOpts
+  );
+
   const swapRouter = new ethers.ContractFactory(
     SwapRouter.abi,
     SwapRouter.bytecode,
@@ -189,7 +198,7 @@ export const createUniswapV3Pool = async (
   token1: string,
   fee = 3000 // Default fee tier 0.3%
 ) => {
-  await uniswapV3FactoryInstance.createPool(token0, token1, fee);
+  await uniswapV3FactoryInstance.createPool(token0, token1, fee, deployOpts);
   const poolAddress = await uniswapV3FactoryInstance.getPool(
     token0,
     token1,
@@ -204,7 +213,7 @@ export const createUniswapV3Pool = async (
   // Initialize the pool with a sqrt price of 1 (equal amounts of both tokens)
   // sqrtPriceX96 = sqrt(1) * 2^96
   const sqrtPriceX96 = ethers.toBigInt("79228162514264337593543950336");
-  await pool.initialize(sqrtPriceX96);
+  await pool.initialize(sqrtPriceX96, deployOpts);
 
   return pool;
 };
@@ -250,7 +259,8 @@ export const addLiquidityV3 = async (
     token1,
   };
 
-  const tx = await nonfungiblePositionManager.mint(params);
+  // Provide manual gas to avoid estimateGas failures on anvil 1.3.x
+  const tx = await nonfungiblePositionManager.mint(params, deployOpts);
   const receipt = await tx.wait();
 
   const iface = nonfungiblePositionManager.interface;


### PR DESCRIPTION
Added explicit fee tier enabling on the Uniswap V3 factory and set manual gas via deployOpts for createPool, initialize, and mint to avoid estimateGas failures on anvil v1.3.1.

```
foundryup -i v1.3.1 
```

```
yarn -s localnet start
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Uniswap V3 deployments now come with standard fee tiers enabled by default (0.05%, 0.3%, 1%), simplifying pool setup.

* **Bug Fixes**
  * Improved reliability of token approvals, pool creation, initialization, and liquidity minting by consistently applying transaction options, reducing failed or stuck transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->