### PR TITLE
fix: add TON to contract registry to fix init process

### DIFF
--- a/src/chains/ton/node.ts
+++ b/src/chains/ton/node.ts
@@ -42,7 +42,10 @@ async function startContainer(dockerImage: string): Promise<Container> {
     },
     HostConfig: {
       AutoRemove: true,
-      NetworkMode: "host",
+      PortBindings: {
+        [`${cfg.PORT_SIDECAR}/tcp`]: [{ HostPort: `${cfg.PORT_SIDECAR}` }],
+        [`${cfg.PORT_RPC}/tcp`]: [{ HostPort: `${cfg.PORT_RPC}` }],
+      },
     },
     Image: dockerImage,
     name: cfg.CONTAINER_NAME,

--- a/src/chains/ton/setup.ts
+++ b/src/chains/ton/setup.ts
@@ -4,7 +4,9 @@ import { GatewayOp } from "@zetachain/protocol-contracts-ton/dist/types";
 import { Gateway } from "@zetachain/protocol-contracts-ton/dist/wrappers/Gateway";
 import { ethers, NonceManager } from "ethers";
 
+import { NetworkID } from "../../constants";
 import { logger } from "../../logger";
+import { registerContracts } from "../../utils";
 import { zetachainDeposit } from "../zetachain/deposit";
 import { zetachainDepositAndCall } from "../zetachain/depositAndCall";
 import { zetachainExecute } from "../zetachain/execute";
@@ -125,6 +127,25 @@ async function setupThrowable(opts: SetupOptions) {
     ],
     env,
   };
+
+  const changeChainStatus =
+    await opts.zetachainContracts.coreRegistry.changeChainStatus(
+      BigInt(NetworkID.TON),
+      ethers.ZeroAddress,
+      "0x",
+      true,
+      {
+        gasLimit: 1_000_000,
+      }
+    );
+
+  await changeChainStatus.wait();
+
+  await registerContracts(opts.zetachainContracts.coreRegistry, NetworkID.TON, {
+    gateway: ethers.hexlify(
+      ethers.toUtf8Bytes(`${gateway.address.toRawString()}`)
+    ),
+  });
 
   log.info("TON setup complete");
   return result;


### PR DESCRIPTION
TON init failed because the network wasn't added to the registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved TON chain initialization with explicit chain-status updates and on-chain contract registration to strengthen deployment reliability.
  * Adjusted local node networking from host mode to explicit port bindings for clearer port exposure and more predictable network behavior.
  * Minor sequencing and logging refinements to ensure setup completes after registry and registration steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->